### PR TITLE
Elements now refer to their children in a way that supports mutability.

### DIFF
--- a/src/lib/lspace/elements/column.rs
+++ b/src/lib/lspace/elements/column.rs
@@ -1,5 +1,7 @@
 use cairo::Context;
 
+use std::cell::{Ref, RefMut};
+
 use layout::lreq::LReq;
 use layout::lalloc::LAlloc;
 use layout::vertical_layout;
@@ -48,14 +50,16 @@ impl TElement for ColumnElement {
 
     fn update_x_req(&mut self) {
         self.update_children_x_req();
-        let child_x_reqs: Vec<&LReq> = self.children.iter().map(|c| c.get().x_req()).collect();
+        let child_refs: Vec<Ref<Box<TElement>>> = self.children.iter().map(|c| c.get()).collect();
+        let child_x_reqs: Vec<&LReq> = child_refs.iter().map(|c| c.x_req()).collect();
         self.req.x_req = vertical_layout::requisition_x(&child_x_reqs);
     }
 
     fn allocate_x(&mut self) {
         {
-            let mut x_pairs: Vec<(&LReq, &mut LAlloc)> = self.children.iter_mut().map(
-                    |c| c.get_mut().x_req_and_mut_alloc()).collect();
+            let mut child_refs: Vec<RefMut<Box<TElement>>> = self.children.iter_mut().map(|c| c.get_mut()).collect();
+            let mut x_pairs: Vec<(&LReq, &mut LAlloc)> = child_refs.iter_mut().map(
+                    |c| c.x_req_and_mut_alloc()).collect();
             vertical_layout::alloc_x(&self.req.x_req,
                     &self.alloc.x_alloc.without_position(), &mut x_pairs);
         }
@@ -64,14 +68,16 @@ impl TElement for ColumnElement {
 
     fn update_y_req(&mut self) {
         self.update_children_y_req();
-        let child_y_reqs: Vec<&LReq> = self.children.iter().map(|c| c.get().y_req()).collect();
+        let child_refs: Vec<Ref<Box<TElement>>> = self.children.iter().map(|c| c.get()).collect();
+        let child_y_reqs: Vec<&LReq> = child_refs.iter().map(|c| c.y_req()).collect();
         self.req.y_req = vertical_layout::requisition_y(&child_y_reqs, self.y_spacing, None);
     }
 
     fn allocate_y(&mut self) {
         {
-            let mut y_pairs: Vec<(&LReq, &mut LAlloc)> = self.children.iter_mut().map(
-                    |c| c.get_mut().y_req_and_mut_alloc()).collect();
+            let mut child_refs: Vec<RefMut<Box<TElement>>> = self.children.iter_mut().map(|c| c.get_mut()).collect();
+            let mut y_pairs: Vec<(&LReq, &mut LAlloc)> = child_refs.iter_mut().map(
+                    |c| c.y_req_and_mut_alloc()).collect();
             vertical_layout::alloc_y(&self.req.y_req,
                     &self.alloc.y_alloc.without_position(),
                     &mut y_pairs, self.y_spacing, None);

--- a/src/lib/lspace/elements/element.rs
+++ b/src/lib/lspace/elements/element.rs
@@ -1,7 +1,7 @@
 use cairo::Context;
 
 use std::rc::Rc;
-use std::cell::RefCell;
+use std::cell::{RefCell, Ref, RefMut};
 
 use layout::lreq::LReq;
 use layout::lalloc::LAlloc;
@@ -16,21 +16,21 @@ const LAYOUT_FLAGS_ALL_CLEAN: u8        = 0b00000000;
 
 
 pub struct ElementChildRef {
-    x: Box<TElement>
+    x: Rc<RefCell<Box<TElement>>>
 }
 
 
 impl ElementChildRef {
     pub fn new<T: TElement + 'static>(x: T) -> ElementChildRef {
-        return ElementChildRef{x: Box::new(x)};
+        return ElementChildRef{x: Rc::new(RefCell::new(Box::new(x)))};
     }
 
-    pub fn get<'a>(&'a self) -> &'a TElement {
-        return &*self.x;
+    pub fn get(&self) -> Ref<Box<TElement>> {
+        return self.x.borrow();
     }
 
-    pub fn get_mut<'a>(&'a mut self) -> &'a mut TElement {
-        return &mut *self.x;
+    pub fn get_mut(&mut self) -> RefMut<Box<TElement>> {
+        return self.x.borrow_mut();
     }
 }
 

--- a/src/lib/lspace/elements/flow.rs
+++ b/src/lib/lspace/elements/flow.rs
@@ -1,5 +1,7 @@
 use cairo::Context;
 
+use std::cell::{Ref, RefMut};
+
 use layout::lreq::LReq;
 use layout::lalloc::LAlloc;
 use layout::flow_layout;
@@ -50,14 +52,16 @@ impl TElement for FlowElement {
 
     fn update_x_req(&mut self) {
         self.update_children_x_req();
-        let child_x_reqs: Vec<&LReq> = self.children.iter().map(|c| c.get().x_req()).collect();
+        let child_refs: Vec<Ref<Box<TElement>>> = self.children.iter().map(|c| c.get()).collect();
+        let child_x_reqs: Vec<&LReq> = child_refs.iter().map(|c| c.x_req()).collect();
         self.req.x_req = flow_layout::requisition_x(&child_x_reqs, self.x_spacing, self.indentation);
     }
 
     fn allocate_x(&mut self) {
         {
-            let mut x_pairs: Vec<(&LReq, &mut LAlloc)> = self.children.iter_mut().map(
-                    |c| c.get_mut().x_req_and_mut_alloc()).collect();
+            let mut child_refs: Vec<RefMut<Box<TElement>>> = self.children.iter_mut().map(|c| c.get_mut()).collect();
+            let mut x_pairs: Vec<(&LReq, &mut LAlloc)> = child_refs.iter_mut().map(
+                    |c| c.x_req_and_mut_alloc()).collect();
             self.lines = flow_layout::alloc_x(&self.req.x_req,
                     &self.alloc.x_alloc.without_position(),
                     &mut x_pairs, self.x_spacing, self.indentation);
@@ -68,14 +72,16 @@ impl TElement for FlowElement {
 
     fn update_y_req(&mut self) {
         self.update_children_y_req();
-        let child_y_reqs: Vec<&LReq> = self.children.iter().map(|c| c.get().y_req()).collect();
+        let child_refs: Vec<Ref<Box<TElement>>> = self.children.iter().map(|c| c.get()).collect();
+        let child_y_reqs: Vec<&LReq> = child_refs.iter().map(|c| c.y_req()).collect();
         self.req.y_req = flow_layout::requisition_y(&child_y_reqs, self.y_spacing, &mut self.lines);
     }
 
     fn allocate_y(&mut self) {
         {
-            let mut y_pairs: Vec<(&LReq, &mut LAlloc)> = self.children.iter_mut().map(
-                    |c| c.get_mut().y_req_and_mut_alloc()).collect();
+            let mut child_refs: Vec<RefMut<Box<TElement>>> = self.children.iter_mut().map(|c| c.get_mut()).collect();
+            let mut y_pairs: Vec<(&LReq, &mut LAlloc)> = child_refs.iter_mut().map(
+                    |c| c.y_req_and_mut_alloc()).collect();
             flow_layout::alloc_y(&self.req.y_req,
                 &self.alloc.y_alloc.without_position(),
                 &mut y_pairs, self.y_spacing, &mut self.lines);

--- a/src/lib/lspace/elements/row.rs
+++ b/src/lib/lspace/elements/row.rs
@@ -1,5 +1,7 @@
 use cairo::Context;
 
+use std::cell::{Ref, RefMut};
+
 use layout::lreq::LReq;
 use layout::lalloc::LAlloc;
 use layout::horizontal_layout;
@@ -48,14 +50,16 @@ impl TElement for RowElement {
 
     fn update_x_req(&mut self) {
         self.update_children_x_req();
-        let child_x_reqs: Vec<&LReq> = self.children.iter().map(|c| c.get().x_req()).collect();
+        let child_refs: Vec<Ref<Box<TElement>>> = self.children.iter().map(|c| c.get()).collect();
+        let child_x_reqs: Vec<&LReq> = child_refs.iter().map(|c| c.x_req()).collect();
         self.req.x_req = horizontal_layout::requisition_x(&child_x_reqs, self.x_spacing);
     }
 
     fn allocate_x(&mut self) {
         {
-            let mut x_pairs: Vec<(&LReq, &mut LAlloc)> = self.children.iter_mut().map(
-                    |c| c.get_mut().x_req_and_mut_alloc()).collect();
+            let mut child_refs: Vec<RefMut<Box<TElement>>> = self.children.iter_mut().map(|c| c.get_mut()).collect();
+            let mut x_pairs: Vec<(&LReq, &mut LAlloc)> = child_refs.iter_mut().map(
+                    |c| c.x_req_and_mut_alloc()).collect();
             horizontal_layout::alloc_x(&self.req.x_req,
                     &self.alloc.x_alloc.without_position(), &mut x_pairs, self.x_spacing);
         }
@@ -64,14 +68,16 @@ impl TElement for RowElement {
 
     fn update_y_req(&mut self) {
         self.update_children_y_req();
-        let child_y_reqs: Vec<&LReq> = self.children.iter().map(|c| c.get().y_req()).collect();
+        let child_refs: Vec<Ref<Box<TElement>>> = self.children.iter().map(|c| c.get()).collect();
+        let child_y_reqs: Vec<&LReq> = child_refs.iter().map(|c| c.y_req()).collect();
         self.req.y_req = horizontal_layout::requisition_y(&child_y_reqs);
     }
 
     fn allocate_y(&mut self) {
         {
-            let mut y_pairs: Vec<(&LReq, &mut LAlloc)> = self.children.iter_mut().map(
-                    |c| c.get_mut().y_req_and_mut_alloc()).collect();
+            let mut child_refs: Vec<RefMut<Box<TElement>>> = self.children.iter_mut().map(|c| c.get_mut()).collect();
+            let mut y_pairs: Vec<(&LReq, &mut LAlloc)> = child_refs.iter_mut().map(
+                    |c| c.y_req_and_mut_alloc()).collect();
             horizontal_layout::alloc_y(&self.req.y_req,
                     &self.alloc.y_alloc.without_position(),
                     &mut y_pairs);


### PR DESCRIPTION
The prior implementation of the element tree would not permit its contents to be modified after creation. This PR addresses this.
