### PR TITLE
Small element system refactoring.

### DIFF
--- a/src/lib/lspace/elements/column.rs
+++ b/src/lib/lspace/elements/column.rs
@@ -7,27 +7,28 @@ use layout::lalloc::LAlloc;
 use layout::vertical_layout;
 use geom::bbox2::BBox2;
 
-use elements::element::{ElementReq, ElementAlloc, TElementLayout, TElement, ElementChildRef};
+use elements::element_layout::{ElementReq, ElementAlloc};
+use elements::element::{TElement, ElementRef, ElemBorrow, ElemBorrowMut};
 use elements::container::TContainerElement;
 
 
 pub struct ColumnElement {
     req: ElementReq,
     alloc: ElementAlloc,
-    children: Vec<ElementChildRef>,
+    children: Vec<ElementRef>,
     y_spacing: f64,
 }
 
 
 impl ColumnElement {
-    pub fn new(children: Vec<ElementChildRef>, y_spacing: f64) -> ColumnElement {
+    pub fn new(children: Vec<ElementRef>, y_spacing: f64) -> ColumnElement {
         return ColumnElement{req: ElementReq::new(), alloc: ElementAlloc::new(), children: children,
                              y_spacing: y_spacing};
     }
 }
 
 
-impl TElementLayout for ColumnElement {
+impl TElement for ColumnElement {
     fn element_req(&self) -> &ElementReq {
         return &self.req;
     }
@@ -39,10 +40,8 @@ impl TElementLayout for ColumnElement {
     fn element_req_and_mut_alloc(&mut self) -> (&ElementReq, &mut ElementAlloc) {
         return (&self.req, &mut self.alloc);
     }
-}
 
 
-impl TElement for ColumnElement {
     fn draw(&self, cairo_ctx: &Context, visible_region: &BBox2) {
         self.draw_self(cairo_ctx, visible_region);
         self.draw_children(cairo_ctx, visible_region);
@@ -50,14 +49,14 @@ impl TElement for ColumnElement {
 
     fn update_x_req(&mut self) {
         self.update_children_x_req();
-        let child_refs: Vec<Ref<Box<TElement>>> = self.children.iter().map(|c| c.get()).collect();
+        let child_refs: Vec<ElemBorrow> = self.children.iter().map(|c| c.get()).collect();
         let child_x_reqs: Vec<&LReq> = child_refs.iter().map(|c| c.x_req()).collect();
         self.req.x_req = vertical_layout::requisition_x(&child_x_reqs);
     }
 
     fn allocate_x(&mut self) {
         {
-            let mut child_refs: Vec<RefMut<Box<TElement>>> = self.children.iter_mut().map(|c| c.get_mut()).collect();
+            let mut child_refs: Vec<ElemBorrowMut> = self.children.iter_mut().map(|c| c.get_mut()).collect();
             let mut x_pairs: Vec<(&LReq, &mut LAlloc)> = child_refs.iter_mut().map(
                     |c| c.x_req_and_mut_alloc()).collect();
             vertical_layout::alloc_x(&self.req.x_req,
@@ -68,14 +67,14 @@ impl TElement for ColumnElement {
 
     fn update_y_req(&mut self) {
         self.update_children_y_req();
-        let child_refs: Vec<Ref<Box<TElement>>> = self.children.iter().map(|c| c.get()).collect();
+        let child_refs: Vec<ElemBorrow> = self.children.iter().map(|c| c.get()).collect();
         let child_y_reqs: Vec<&LReq> = child_refs.iter().map(|c| c.y_req()).collect();
         self.req.y_req = vertical_layout::requisition_y(&child_y_reqs, self.y_spacing, None);
     }
 
     fn allocate_y(&mut self) {
         {
-            let mut child_refs: Vec<RefMut<Box<TElement>>> = self.children.iter_mut().map(|c| c.get_mut()).collect();
+            let mut child_refs: Vec<ElemBorrowMut> = self.children.iter_mut().map(|c| c.get_mut()).collect();
             let mut y_pairs: Vec<(&LReq, &mut LAlloc)> = child_refs.iter_mut().map(
                     |c| c.y_req_and_mut_alloc()).collect();
             vertical_layout::alloc_y(&self.req.y_req,
@@ -88,11 +87,11 @@ impl TElement for ColumnElement {
 
 
 impl TContainerElement for ColumnElement {
-    fn children<'a>(&'a self) -> &'a Vec<ElementChildRef> {
+    fn children<'a>(&'a self) -> &'a Vec<ElementRef> {
         return &self.children;
     }
 
-    fn children_mut<'a>(&'a mut self) -> &'a mut Vec<ElementChildRef> {
+    fn children_mut<'a>(&'a mut self) -> &'a mut Vec<ElementRef> {
         return &mut self.children;
     }
 }

--- a/src/lib/lspace/elements/container.rs
+++ b/src/lib/lspace/elements/container.rs
@@ -3,12 +3,12 @@ use cairo::Context;
 use geom::vector2::Vector2;
 use geom::bbox2::BBox2;
 
-use elements::element::{TElement, ElementChildRef};
+use elements::element::{TElement, ElementRef};
 
 
 pub trait TContainerElement : TElement {
-    fn children<'a>(&'a self) -> &'a Vec<ElementChildRef>;
-    fn children_mut<'a>(&'a mut self) -> &'a mut Vec<ElementChildRef>;
+    fn children<'a>(&'a self) -> &'a Vec<ElementRef>;
+    fn children_mut<'a>(&'a mut self) -> &'a mut Vec<ElementRef>;
 
     fn draw_children(&self, cairo_ctx: &Context, visible_region: &BBox2) {
         for chref in self.children() {

--- a/src/lib/lspace/elements/element_ctx.rs
+++ b/src/lib/lspace/elements/element_ctx.rs
@@ -6,7 +6,7 @@ use cairo::Context;
 
 use layout::lreq::LReq;
 
-use elements::element::ElementReq;
+use elements::element_layout::ElementReq;
 use elements::text_element::{TextReqKey, TextStyleParams};
 
 

--- a/src/lib/lspace/elements/element_layout.rs
+++ b/src/lib/lspace/elements/element_layout.rs
@@ -1,0 +1,40 @@
+use layout::lreq::LReq;
+use layout::lalloc::LAlloc;
+use geom::bbox2::BBox2;
+
+const LAYOUT_FLAG_X_REQ_DIRTY: u8       = 0b0001;
+const LAYOUT_FLAG_Y_REQ_DIRTY: u8       = 0b0010;
+const LAYOUT_FLAG_X_ALLOC_DIRTY: u8     = 0b0100;
+const LAYOUT_FLAG_Y_ALLOC_DIRTY: u8     = 0b1000;
+const LAYOUT_FLAGS_ALL_DIRTY: u8        = 0b1111;
+const LAYOUT_FLAGS_ALL_CLEAN: u8        = 0b0000;
+
+
+pub struct ElementReq {
+    pub x_req: LReq,
+    pub y_req: LReq,
+}
+
+impl ElementReq {
+    pub fn new() -> ElementReq {
+        return ElementReq{x_req: LReq::new_empty(), y_req: LReq::new_empty()};
+    }
+
+    pub fn new_from_reqs(x_req: LReq, y_req: LReq) -> ElementReq {
+        return ElementReq{x_req: x_req, y_req: y_req};
+    }
+}
+
+
+pub struct ElementAlloc {
+    pub x_alloc: LAlloc,
+    pub y_alloc: LAlloc,
+    pub layout_flags: u8,
+}
+
+impl ElementAlloc {
+    pub fn new() -> ElementAlloc {
+        return ElementAlloc{x_alloc: LAlloc::new_empty(), y_alloc: LAlloc::new_empty(),
+                            layout_flags: LAYOUT_FLAGS_ALL_CLEAN};
+    }
+}

--- a/src/lib/lspace/elements/flow.rs
+++ b/src/lib/lspace/elements/flow.rs
@@ -7,14 +7,15 @@ use layout::lalloc::LAlloc;
 use layout::flow_layout;
 use geom::bbox2::BBox2;
 
-use elements::element::{ElementReq, ElementAlloc, TElementLayout, TElement, ElementChildRef};
+use elements::element_layout::{ElementReq, ElementAlloc};
+use elements::element::{TElement, ElementRef, ElemBorrow, ElemBorrowMut};
 use elements::container::TContainerElement;
 
 
 pub struct FlowElement {
     req: ElementReq,
     alloc: ElementAlloc,
-    children: Vec<ElementChildRef>,
+    children: Vec<ElementRef>,
     x_spacing: f64,
     y_spacing: f64,
     indentation: flow_layout::FlowIndent,
@@ -22,7 +23,7 @@ pub struct FlowElement {
 }
 
 impl FlowElement {
-    pub fn new(children: Vec<ElementChildRef>, x_spacing: f64, y_spacing: f64,
+    pub fn new(children: Vec<ElementRef>, x_spacing: f64, y_spacing: f64,
                indentation: flow_layout::FlowIndent) -> FlowElement {
         return FlowElement{req: ElementReq::new(), alloc: ElementAlloc::new(),
                            children: children, x_spacing: x_spacing, y_spacing: y_spacing,
@@ -30,7 +31,7 @@ impl FlowElement {
     }
 }
 
-impl TElementLayout for FlowElement {
+impl TElement for FlowElement {
     fn element_req(&self) -> &ElementReq {
         return &self.req;
     }
@@ -42,9 +43,7 @@ impl TElementLayout for FlowElement {
     fn element_req_and_mut_alloc(&mut self) -> (&ElementReq, &mut ElementAlloc) {
         return (&self.req, &mut self.alloc);
     }
-}
 
-impl TElement for FlowElement {
     fn draw(&self, cairo_ctx: &Context, visible_region: &BBox2) {
         self.draw_self(cairo_ctx, visible_region);
         self.draw_children(cairo_ctx, visible_region);
@@ -52,14 +51,14 @@ impl TElement for FlowElement {
 
     fn update_x_req(&mut self) {
         self.update_children_x_req();
-        let child_refs: Vec<Ref<Box<TElement>>> = self.children.iter().map(|c| c.get()).collect();
+        let child_refs: Vec<ElemBorrow> = self.children.iter().map(|c| c.get()).collect();
         let child_x_reqs: Vec<&LReq> = child_refs.iter().map(|c| c.x_req()).collect();
         self.req.x_req = flow_layout::requisition_x(&child_x_reqs, self.x_spacing, self.indentation);
     }
 
     fn allocate_x(&mut self) {
         {
-            let mut child_refs: Vec<RefMut<Box<TElement>>> = self.children.iter_mut().map(|c| c.get_mut()).collect();
+            let mut child_refs: Vec<ElemBorrowMut> = self.children.iter_mut().map(|c| c.get_mut()).collect();
             let mut x_pairs: Vec<(&LReq, &mut LAlloc)> = child_refs.iter_mut().map(
                     |c| c.x_req_and_mut_alloc()).collect();
             self.lines = flow_layout::alloc_x(&self.req.x_req,
@@ -72,14 +71,14 @@ impl TElement for FlowElement {
 
     fn update_y_req(&mut self) {
         self.update_children_y_req();
-        let child_refs: Vec<Ref<Box<TElement>>> = self.children.iter().map(|c| c.get()).collect();
+        let child_refs: Vec<ElemBorrow> = self.children.iter().map(|c| c.get()).collect();
         let child_y_reqs: Vec<&LReq> = child_refs.iter().map(|c| c.y_req()).collect();
         self.req.y_req = flow_layout::requisition_y(&child_y_reqs, self.y_spacing, &mut self.lines);
     }
 
     fn allocate_y(&mut self) {
         {
-            let mut child_refs: Vec<RefMut<Box<TElement>>> = self.children.iter_mut().map(|c| c.get_mut()).collect();
+            let mut child_refs: Vec<ElemBorrowMut> = self.children.iter_mut().map(|c| c.get_mut()).collect();
             let mut y_pairs: Vec<(&LReq, &mut LAlloc)> = child_refs.iter_mut().map(
                     |c| c.y_req_and_mut_alloc()).collect();
             flow_layout::alloc_y(&self.req.y_req,
@@ -92,11 +91,11 @@ impl TElement for FlowElement {
 
 
 impl TContainerElement for FlowElement {
-    fn children<'a>(&'a self) -> &'a Vec<ElementChildRef> {
+    fn children<'a>(&'a self) -> &'a Vec<ElementRef> {
         return &self.children;
     }
 
-    fn children_mut<'a>(&'a mut self) -> &'a mut Vec<ElementChildRef> {
+    fn children_mut<'a>(&'a mut self) -> &'a mut Vec<ElementRef> {
         return &mut self.children;
     }
 }

--- a/src/lib/lspace/elements/mod.rs
+++ b/src/lib/lspace/elements/mod.rs
@@ -1,4 +1,5 @@
 pub mod element_ctx;
+pub mod element_layout;
 pub mod element;
 pub mod container;
 pub mod text_element;

--- a/src/lib/lspace/elements/root_element.rs
+++ b/src/lib/lspace/elements/root_element.rs
@@ -3,18 +3,19 @@ use cairo::Context;
 use layout::lalloc::LAlloc;
 use geom::bbox2::BBox2;
 
-use elements::element::{ElementReq, ElementAlloc, TElementLayout, TElement, ElementChildRef};
+use elements::element_layout::{ElementReq, ElementAlloc};
+use elements::element::{TElement, ElementRef};
 use elements::container::TContainerElement;
 
 
 pub struct RootElement {
     req: ElementReq,
     alloc: ElementAlloc,
-    children: Vec<ElementChildRef>,
+    children: Vec<ElementRef>,
 }
 
 impl RootElement {
-    pub fn new(child: ElementChildRef) -> RootElement {
+    pub fn new(child: ElementRef) -> RootElement {
         return RootElement{req: ElementReq::new(), alloc: ElementAlloc::new(),
                            children: vec![child]};
     }
@@ -40,7 +41,7 @@ impl RootElement {
     }
 }
 
-impl TElementLayout for RootElement {
+impl TElement for RootElement {
     fn element_req(&self) -> &ElementReq {
         return &self.req;
     }
@@ -52,9 +53,7 @@ impl TElementLayout for RootElement {
     fn element_req_and_mut_alloc(&mut self) -> (&ElementReq, &mut ElementAlloc) {
         return (&self.req, &mut self.alloc);
     }
-}
 
-impl TElement for RootElement {
     fn draw(&self, cairo_ctx: &Context, visible_region: &BBox2) {
         self.draw_self(cairo_ctx, visible_region);
         self.draw_children(cairo_ctx, visible_region);
@@ -83,11 +82,11 @@ impl TElement for RootElement {
 }
 
 impl TContainerElement for RootElement {
-    fn children<'a>(&'a self) -> &'a Vec<ElementChildRef> {
+    fn children<'a>(&'a self) -> &'a Vec<ElementRef> {
         return &self.children;
     }
 
-    fn children_mut<'a>(&'a mut self) -> &'a mut Vec<ElementChildRef> {
+    fn children_mut<'a>(&'a mut self) -> &'a mut Vec<ElementRef> {
         return &mut self.children;
     }
 }

--- a/src/lib/lspace/elements/text_element.rs
+++ b/src/lib/lspace/elements/text_element.rs
@@ -10,8 +10,9 @@ use cairo_sys::enums::{FontSlant, FontWeight};
 use layout::lalloc::LAlloc;
 use geom::bbox2::BBox2;
 use geom::colour::{Colour, BLACK};
+use elements::element_layout::{ElementReq, ElementAlloc};
 use elements::element_ctx::{ElementContext};
-use elements::element::{ElementReq, ElementAlloc, TElementLayout, TElement};
+use elements::element::{TElement};
 
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
@@ -119,7 +120,7 @@ impl TextElement {
     }
 }
 
-impl TElementLayout for TextElement {
+impl TElement for TextElement {
     fn element_req(&self) -> &ElementReq {
         return &*self.req;
     }
@@ -131,9 +132,7 @@ impl TElementLayout for TextElement {
     fn element_req_and_mut_alloc(&mut self) -> (&ElementReq, &mut ElementAlloc) {
         return (&*self.req, &mut self.alloc);
     }
-}
 
-impl TElement for TextElement {
     fn draw_self(&self, cairo_ctx: &Context, visible_region: &BBox2) {
         let y = match self.alloc.y_alloc.ref_point() {
             None => 0.0,

--- a/src/lib/lspace/pres/pres.rs
+++ b/src/lib/lspace/pres/pres.rs
@@ -4,7 +4,7 @@ use std::cell::RefCell;
 
 use cairo::Context;
 
-use elements::element::ElementChildRef;
+use elements::element::ElementRef;
 use elements::element_ctx::ElementContext;
 
 
@@ -24,5 +24,5 @@ impl <'a> PresBuildCtx<'a> {
 
 
 pub trait TPres {
-    fn build(&self, pres_ctx: &PresBuildCtx) -> ElementChildRef;
+    fn build(&self, pres_ctx: &PresBuildCtx) -> ElementRef;
 }

--- a/src/lib/lspace/pres/primitive.rs
+++ b/src/lib/lspace/pres/primitive.rs
@@ -2,7 +2,7 @@ use std::rc::Rc;
 use std::cell::RefCell;
 
 use layout::flow_layout;
-use elements::element::{TElement, ElementChildRef};
+use elements::element::{TElement, ElementRef};
 use elements::{text_element, column, row, flow, root_element};
 use pres::pres::{Pres, TPres, PresBuildCtx};
 
@@ -19,10 +19,10 @@ impl Text {
 }
 
 impl TPres for Text {
-    fn build(&self, pres_ctx: &PresBuildCtx) -> ElementChildRef {
+    fn build(&self, pres_ctx: &PresBuildCtx) -> ElementRef {
         let elem = text_element::TextElement::new(self.text.clone(), self.style.clone(),
                                                   pres_ctx.cairo_ctx, &pres_ctx.elem_ctx);
-        return ElementChildRef::new(elem);
+        return ElementRef::new(elem);
     }
 }
 
@@ -38,10 +38,10 @@ impl Column {
 }
 
 impl TPres for Column {
-    fn build(&self, pres_ctx: &PresBuildCtx) -> ElementChildRef {
+    fn build(&self, pres_ctx: &PresBuildCtx) -> ElementRef {
         let child_elems = self.children.iter().map(|p| p.build(pres_ctx)).collect();
         let elem = column::ColumnElement::new(child_elems, 0.0);
-        return ElementChildRef::new(elem);
+        return ElementRef::new(elem);
     }
 }
 
@@ -57,10 +57,10 @@ impl Row {
 }
 
 impl TPres for Row {
-    fn build(&self, pres_ctx: &PresBuildCtx) -> ElementChildRef {
+    fn build(&self, pres_ctx: &PresBuildCtx) -> ElementRef {
         let child_elems = self.children.iter().map(|p| p.build(pres_ctx)).collect();
         let elem = row::RowElement::new(child_elems, 0.0);
-        return ElementChildRef::new(elem);
+        return ElementRef::new(elem);
     }
 }
 
@@ -76,10 +76,10 @@ impl Flow {
 }
 
 impl TPres for Flow {
-    fn build(&self, pres_ctx: &PresBuildCtx) -> ElementChildRef {
+    fn build(&self, pres_ctx: &PresBuildCtx) -> ElementRef {
         let child_elems = self.children.iter().map(|p| p.build(pres_ctx)).collect();
         let elem = flow::FlowElement::new(child_elems, 0.0, 0.0, flow_layout::FlowIndent::NoIndent);
-        return ElementChildRef::new(elem);
+        return ElementRef::new(elem);
     }
 }
 


### PR DESCRIPTION
Refactored element layout types into their own module.
Element borrow types now referred to by type alias.
Renamed ElementChildRef to ElementRef.

This is mainly in aid of the layout system refactoring that will come as an additional PR.
