### PR TITLE
Element interior mutability.

### DIFF
--- a/src/lib/lspace/elements/column.rs
+++ b/src/lib/lspace/elements/column.rs
@@ -1,6 +1,6 @@
 use cairo::Context;
 
-use std::cell::{Ref, RefMut};
+use std::cell::{RefCell, Ref};
 
 use layout::lreq::LReq;
 use layout::lalloc::LAlloc;
@@ -8,42 +8,47 @@ use layout::vertical_layout;
 use geom::bbox2::BBox2;
 
 use elements::element_layout::{ElementReq, ElementAlloc};
-use elements::element::{TElement, ElementRef, ElemBorrow, ElemBorrowMut};
+use elements::element::{TElement, ElementRef};
 use elements::container::TContainerElement;
 
 
-pub struct ColumnElement {
+struct ColumnElementMut {
     req: ElementReq,
     alloc: ElementAlloc,
     children: Vec<ElementRef>,
     y_spacing: f64,
 }
 
+pub struct ColumnElement {
+    m: RefCell<ColumnElementMut>
+}
+
 
 impl ColumnElement {
     pub fn new(children: Vec<ElementRef>, y_spacing: f64) -> ColumnElement {
-        return ColumnElement{req: ElementReq::new(), alloc: ElementAlloc::new(),
-                             children: children, y_spacing: y_spacing};
+        return ColumnElement{m: RefCell::new(ColumnElementMut{
+                                req: ElementReq::new(), alloc: ElementAlloc::new(),
+                                children: children, y_spacing: y_spacing})};
     }
 }
 
 
 impl TElement for ColumnElement {
-    fn element_req(&self) -> &ElementReq {
-        return &self.req;
+    fn element_req(&self) -> Ref<ElementReq> {
+        return Ref::map(self.m.borrow(), |m| &m.req);
     }
 
-    fn element_alloc(&self) -> &ElementAlloc {
-        return &self.alloc;
+    fn element_alloc(&self) -> Ref<ElementAlloc> {
+        return Ref::map(self.m.borrow(), |m| &m.alloc);
     }
 
     /// Update element X allocation
-    fn element_update_x_alloc(&mut self, x_alloc: &LAlloc) {
-        self.alloc.x_alloc.clone_from(x_alloc);
+    fn element_update_x_alloc(&self, x_alloc: &LAlloc) {
+        self.m.borrow_mut().alloc.x_alloc.clone_from(x_alloc);
     }
     /// Update element Y allocation
-    fn element_update_y_alloc(&mut self, y_alloc: &LAlloc) {
-        self.alloc.y_alloc.clone_from(y_alloc);
+    fn element_update_y_alloc(&self, y_alloc: &LAlloc) {
+        self.m.borrow_mut().alloc.y_alloc.clone_from(y_alloc);
     }
 
 
@@ -52,47 +57,57 @@ impl TElement for ColumnElement {
         self.draw_children(cairo_ctx, visible_region);
     }
 
-    fn update_x_req(&mut self) {
+    fn update_x_req(&self) {
         self.update_children_x_req();
-        let child_refs: Vec<ElemBorrow> = self.children.iter().map(|c| c.get()).collect();
-        let child_x_reqs: Vec<&LReq> = child_refs.iter().map(|c| c.x_req()).collect();
-        self.req.x_req = vertical_layout::requisition_x(&child_x_reqs);
+        let mut mm = self.m.borrow_mut();
+        let x_req = {
+            let child_reqs: Vec<Ref<ElementReq>> = mm.children.iter().map(|c| c.element_req()).collect();
+            let child_x_reqs: Vec<&LReq> = child_reqs.iter().map(|c| &c.x_req).collect();
+            vertical_layout::requisition_x(&child_x_reqs)
+        };
+        mm.req.x_req = x_req;
     }
 
-    fn allocate_x(&mut self) {
+    fn allocate_x(&self) {
         {
-            let mut child_refs: Vec<ElemBorrowMut> = self.children.iter().map(
-                        |c| c.get_mut()).collect();
+            let mm = self.m.borrow();
             let x_allocs = {
-                let mut x_reqs: Vec<&LReq> = child_refs.iter().map(|c| c.x_req()).collect();
-                vertical_layout::alloc_x(&self.req.x_req,
-                        &self.alloc.x_alloc.without_position(), &x_reqs)
+                let child_reqs: Vec<Ref<ElementReq>> = mm.children.iter().map(|c| c.element_req()).collect();
+                let child_x_reqs: Vec<&LReq> = child_reqs.iter().map(|c| &c.x_req).collect();
+
+                vertical_layout::alloc_x(&mm.req.x_req,
+                        &mm.alloc.x_alloc.without_position(), &child_x_reqs)
             };
-            for c in child_refs.iter_mut().zip(x_allocs.iter()) {
+            for c in mm.children.iter().zip(x_allocs.iter()) {
                 c.0.element_update_x_alloc(c.1);
             }
         }
         self.allocate_children_x();
     }
 
-    fn update_y_req(&mut self) {
+    fn update_y_req(&self) {
         self.update_children_y_req();
-        let child_refs: Vec<ElemBorrow> = self.children.iter().map(|c| c.get()).collect();
-        let child_y_reqs: Vec<&LReq> = child_refs.iter().map(|c| c.y_req()).collect();
-        self.req.y_req = vertical_layout::requisition_y(&child_y_reqs, self.y_spacing, None);
+        let mut mm = self.m.borrow_mut();
+        let y_req = {
+            let child_reqs: Vec<Ref<ElementReq>> = mm.children.iter().map(|c| c.element_req()).collect();
+            let child_y_reqs: Vec<&LReq> = child_reqs.iter().map(|c| &c.y_req).collect();
+            vertical_layout::requisition_y(&child_y_reqs, mm.y_spacing, None)
+        };
+        mm.req.y_req = y_req;
     }
 
-    fn allocate_y(&mut self) {
+    fn allocate_y(&self) {
         {
-            let mut child_refs: Vec<ElemBorrowMut> = self.children.iter().map(
-                        |c| c.get_mut()).collect();
+            let mm = self.m.borrow();
             let y_allocs = {
-                let y_reqs: Vec<&LReq> = child_refs.iter().map(|c| c.y_req()).collect();
-                vertical_layout::alloc_y(&self.req.y_req,
-                                         &self.alloc.y_alloc.without_position(),
-                                         &y_reqs, self.y_spacing, None)
+                let child_reqs: Vec<Ref<ElementReq>> = mm.children.iter().map(|c| c.element_req()).collect();
+                let child_y_reqs: Vec<&LReq> = child_reqs.iter().map(|c| &c.y_req).collect();
+
+                vertical_layout::alloc_y(&mm.req.y_req,
+                                                        &mm.alloc.y_alloc.without_position(),
+                                                        &child_y_reqs, mm.y_spacing, None)
             };
-            for c in child_refs.iter_mut().zip(y_allocs.iter()) {
+            for c in mm.children.iter().zip(y_allocs.iter()) {
                 c.0.element_update_y_alloc(c.1);
             }
         }
@@ -102,11 +117,7 @@ impl TElement for ColumnElement {
 
 
 impl TContainerElement for ColumnElement {
-    fn children<'a>(&'a self) -> &'a Vec<ElementRef> {
-        return &self.children;
-    }
-
-    fn children_mut<'a>(&'a mut self) -> &'a mut Vec<ElementRef> {
-        return &mut self.children;
+    fn children(&self) -> Ref<Vec<ElementRef>> {
+        return Ref::map(self.m.borrow(), |m| &m.children);
     }
 }

--- a/src/lib/lspace/elements/container.rs
+++ b/src/lib/lspace/elements/container.rs
@@ -1,5 +1,7 @@
 use cairo::Context;
 
+use std::cell::Ref;
+
 use geom::vector2::Vector2;
 use geom::bbox2::BBox2;
 
@@ -7,18 +9,16 @@ use elements::element::{TElement, ElementRef};
 
 
 pub trait TContainerElement : TElement {
-    fn children<'a>(&'a self) -> &'a Vec<ElementRef>;
-    fn children_mut<'a>(&'a mut self) -> &'a mut Vec<ElementRef>;
+    fn children(&self) -> Ref<Vec<ElementRef>>;
 
     fn draw_children(&self, cairo_ctx: &Context, visible_region: &BBox2) {
-        for chref in self.children() {
-            let child = chref.get();
-            let xa = child.x_alloc();
-            let ya = child.y_alloc();
-            let child_bbox = BBox2::from_allocs(xa, ya);
+        for child in self.children().iter() {
+            let a = child.element_alloc();
+            let child_bbox = BBox2::from_allocs(&a.x_alloc, &a.y_alloc);
             if child_bbox.intersects(visible_region) {
-                let dx = xa.pos_in_parent();
-                let dy = ya.pos_in_parent();
+                let dx = a.x_alloc.pos_in_parent();
+                let dy = a.y_alloc
+                .pos_in_parent();
                 let visible_region_child_space = visible_region.offset(&Vector2::new(-dx, -dy));
                 cairo_ctx.save();
                 cairo_ctx.translate(dx, dy);
@@ -28,27 +28,27 @@ pub trait TContainerElement : TElement {
         }
     }
 
-    fn update_children_x_req(&mut self) {
-        for child in self.children_mut() {
-            child.get_mut().update_x_req();
+    fn update_children_x_req(&self) {
+        for child in self.children().iter() {
+            child.update_x_req();
         }
     }
 
-    fn update_children_y_req(&mut self) {
-        for child in self.children_mut() {
-            child.get_mut().update_y_req();
+    fn update_children_y_req(&self) {
+        for child in self.children().iter() {
+            child.update_y_req();
         }
     }
 
-    fn allocate_children_x(&mut self) {
-        for child in self.children_mut() {
-            child.get_mut().allocate_x();
+    fn allocate_children_x(&self) {
+        for child in self.children().iter() {
+            child.allocate_x();
         }
     }
 
-    fn allocate_children_y(&mut self) {
-        for child in self.children_mut() {
-            child.get_mut().allocate_y();
+    fn allocate_children_y(&self) {
+        for child in self.children().iter() {
+            child.allocate_y();
         }
     }
 }

--- a/src/lib/lspace/elements/element.rs
+++ b/src/lib/lspace/elements/element.rs
@@ -1,7 +1,7 @@
 use cairo::Context;
 
 use std::rc::Rc;
-use std::cell::{RefCell, Ref, RefMut};
+use std::cell::{RefCell, Ref};
 
 use layout::lreq::LReq;
 use layout::lalloc::LAlloc;
@@ -10,57 +10,37 @@ use geom::bbox2::BBox2;
 use elements::element_layout::{ElementReq, ElementAlloc};
 
 
-pub type ElemBorrow<'a> = Ref<'a, Box<TElement>>;
-pub type ElemBorrowMut<'a> = RefMut<'a, Box<TElement>>;
-
-
-pub struct ElementRef {
-    x: Rc<RefCell<Box<TElement>>>
-}
-
-impl ElementRef {
-    pub fn new<T: TElement + 'static>(x: T) -> ElementRef {
-        return ElementRef{x: Rc::new(RefCell::new(Box::new(x)))};
-    }
-
-    pub fn get(&self) -> ElemBorrow {
-        return self.x.borrow();
-    }
-
-    pub fn get_mut(&self) -> ElemBorrowMut {
-        return self.x.borrow_mut();
-    }
-}
+pub type ElementRef = Rc<TElement>;
 
 
 pub trait TElement {
     /// Acquire reference to the element layout requisition
-    fn element_req(&self) -> &ElementReq;
+    fn element_req(&self) -> Ref<ElementReq>;
     /// Acquire reference to the element layout allocation
-    fn element_alloc(&self) -> &ElementAlloc;
+    fn element_alloc(&self) -> Ref<ElementAlloc>;
     /// Update element X allocation
-    fn element_update_x_alloc(&mut self, x_alloc: &LAlloc);
+    fn element_update_x_alloc(&self, x_alloc: &LAlloc);
     /// Update element Y allocation
-    fn element_update_y_alloc(&mut self, y_alloc: &LAlloc);
+    fn element_update_y_alloc(&self, y_alloc: &LAlloc);
 
     /// Acquire reference to element layout X requisition
-    fn x_req(&self) -> &LReq {
-        return &self.element_req().x_req;
+    fn x_req(&self) -> Ref<LReq> {
+        return Ref::map(self.element_req(), |r| &r.x_req);
     }
 
     /// Acquire reference to element layout X allocation
-    fn x_alloc(&self) -> &LAlloc {
-        return &self.element_alloc().x_alloc;
+    fn x_alloc(&self) -> Ref<LAlloc> {
+        return Ref::map(self.element_alloc(), |a| &a.x_alloc);
     }
 
     /// Acquire reference to element layout Y requisition
-    fn y_req(&self) -> &LReq {
-        return &self.element_req().y_req;
+    fn y_req(&self) -> Ref<LReq> {
+        return Ref::map(self.element_req(), |r| &r.y_req);
     }
 
     /// Acquire reference to element layout Y allocation
-    fn y_alloc(&self) -> &LAlloc {
-        return &self.element_alloc().y_alloc;
+    fn y_alloc(&self) -> Ref<LAlloc> {
+        return Ref::map(self.element_alloc(), |a| &a.y_alloc);
     }
 
 
@@ -73,14 +53,14 @@ pub trait TElement {
     fn draw(&self, cairo_ctx: &Context, visible_region: &BBox2);
 
     /// Update layout: X requisition
-    fn update_x_req(&mut self);
+    fn update_x_req(&self);
 
     /// Update layout: X allocation
-    fn allocate_x(&mut self);
+    fn allocate_x(&self);
 
     /// Update layout: Y requisition
-    fn update_y_req(&mut self);
+    fn update_y_req(&self);
 
     /// Update layout: Y allocation
-    fn allocate_y(&mut self);
+    fn allocate_y(&self);
 }

--- a/src/lib/lspace/elements/flow.rs
+++ b/src/lib/lspace/elements/flow.rs
@@ -1,6 +1,6 @@
 use cairo::Context;
 
-use std::cell::{Ref, RefMut};
+use std::cell::{RefCell, Ref};
 
 use layout::lreq::LReq;
 use layout::lalloc::LAlloc;
@@ -8,45 +8,51 @@ use layout::flow_layout;
 use geom::bbox2::BBox2;
 
 use elements::element_layout::{ElementReq, ElementAlloc};
-use elements::element::{TElement, ElementRef, ElemBorrow, ElemBorrowMut};
+use elements::element::{TElement, ElementRef};
 use elements::container::TContainerElement;
 
 
-pub struct FlowElement {
+pub struct FlowElementMut {
     req: ElementReq,
     alloc: ElementAlloc,
     children: Vec<ElementRef>,
     x_spacing: f64,
     y_spacing: f64,
     indentation: flow_layout::FlowIndent,
-    lines: Vec<flow_layout::FlowLine>
+}
+
+
+pub struct FlowElement {
+    m: RefCell<FlowElementMut>,
+    m_lines: RefCell<Vec<flow_layout::FlowLine>>
 }
 
 impl FlowElement {
     pub fn new(children: Vec<ElementRef>, x_spacing: f64, y_spacing: f64,
                indentation: flow_layout::FlowIndent) -> FlowElement {
-        return FlowElement{req: ElementReq::new(), alloc: ElementAlloc::new(),
-                           children: children, x_spacing: x_spacing, y_spacing: y_spacing,
-                           indentation: indentation, lines: Vec::new()};
+        return FlowElement{m: RefCell::new(FlowElementMut{
+                                req: ElementReq::new(), alloc: ElementAlloc::new(),
+                                children: children, x_spacing: x_spacing, y_spacing: y_spacing,
+                                indentation: indentation}), m_lines: RefCell::new(Vec::new())};
     }
 }
 
 impl TElement for FlowElement {
-    fn element_req(&self) -> &ElementReq {
-        return &self.req;
+    fn element_req(&self) -> Ref<ElementReq> {
+        return Ref::map(self.m.borrow(), |m| &m.req);
     }
 
-    fn element_alloc(&self) -> &ElementAlloc {
-        return &self.alloc;
+    fn element_alloc(&self) -> Ref<ElementAlloc> {
+        return Ref::map(self.m.borrow(), |m| &m.alloc);
     }
 
     /// Update element X allocation
-    fn element_update_x_alloc(&mut self, x_alloc: &LAlloc) {
-        self.alloc.x_alloc.clone_from(x_alloc);
+    fn element_update_x_alloc(&self, x_alloc: &LAlloc) {
+        self.m.borrow_mut().alloc.x_alloc.clone_from(x_alloc);
     }
     /// Update element Y allocation
-    fn element_update_y_alloc(&mut self, y_alloc: &LAlloc) {
-        self.alloc.y_alloc.clone_from(y_alloc);
+    fn element_update_y_alloc(&self, y_alloc: &LAlloc) {
+        self.m.borrow_mut().alloc.y_alloc.clone_from(y_alloc);
     }
 
     fn draw(&self, cairo_ctx: &Context, visible_region: &BBox2) {
@@ -54,50 +60,62 @@ impl TElement for FlowElement {
         self.draw_children(cairo_ctx, visible_region);
     }
 
-    fn update_x_req(&mut self) {
+    fn update_x_req(&self) {
         self.update_children_x_req();
-        let child_refs: Vec<ElemBorrow> = self.children.iter().map(|c| c.get()).collect();
-        let child_x_reqs: Vec<&LReq> = child_refs.iter().map(|c| c.x_req()).collect();
-        self.req.x_req = flow_layout::requisition_x(&child_x_reqs, self.x_spacing,
-                                                    self.indentation);
+        let mut mm = self.m.borrow_mut();
+        let x_req = {
+            let child_reqs: Vec<Ref<ElementReq>> = mm.children.iter().map(|c| c.element_req()).collect();
+            let child_x_reqs: Vec<&LReq> = child_reqs.iter().map(|c| &c.x_req).collect();
+            flow_layout::requisition_x(&child_x_reqs, mm.x_spacing, mm.indentation)
+        };
+        mm.req.x_req = x_req;
     }
 
-    fn allocate_x(&mut self) {
+    fn allocate_x(&self) {
         {
-            let mut child_refs: Vec<ElemBorrowMut> = self.children.iter().map(
-                        |c| c.get_mut()).collect();
+            let mm = self.m.borrow();
             let allocs_and_lines = {
-                let x_reqs: Vec<&LReq> = child_refs.iter().map(|c| c.x_req()).collect();
-                flow_layout::alloc_x(&self.req.x_req, &self.alloc.x_alloc.without_position(),
-                                     &x_reqs, self.x_spacing, self.indentation)
+                let child_reqs: Vec<Ref<ElementReq>> = mm.children.iter().map(|c| c.element_req()).collect();
+                let child_x_reqs: Vec<&LReq> = child_reqs.iter().map(|c| &c.x_req).collect();
+
+                flow_layout::alloc_x(&mm.req.x_req, &mm.alloc.x_alloc.without_position(),
+                                         &child_x_reqs, mm.x_spacing, mm.indentation)
             };
-            self.lines = allocs_and_lines.1;
-            for c in child_refs.iter_mut().zip(allocs_and_lines.0.iter()) {
+            (*self.m_lines.borrow_mut()).clone_from(&allocs_and_lines.1);
+            for c in mm.children.iter().zip(allocs_and_lines.0.iter()) {
                 c.0.element_update_x_alloc(c.1);
             }
         }
         self.allocate_children_x();
     }
 
-    fn update_y_req(&mut self) {
+    fn update_y_req(&self) {
         self.update_children_y_req();
-        let child_refs: Vec<ElemBorrow> = self.children.iter().map(|c| c.get()).collect();
-        let child_y_reqs: Vec<&LReq> = child_refs.iter().map(|c| c.y_req()).collect();
-        self.req.y_req = flow_layout::requisition_y(&child_y_reqs, self.y_spacing,
-                                                    &mut self.lines);
+        let mut mm = self.m.borrow_mut();
+        let mut b_lines = self.m_lines.borrow_mut();
+        let mut lines: &mut Vec<flow_layout::FlowLine> = &mut (*b_lines);
+        let y_req = {
+            let child_reqs: Vec<Ref<ElementReq>> = mm.children.iter().map(|c| c.element_req()).collect();
+            let child_y_reqs: Vec<&LReq> = child_reqs.iter().map(|c| &c.y_req).collect();
+            flow_layout::requisition_y(&child_y_reqs, mm.y_spacing, lines)
+        };
+        mm.req.y_req = y_req;
     }
 
-    fn allocate_y(&mut self) {
+    fn allocate_y(&self) {
         {
-            let mut child_refs: Vec<ElemBorrowMut> = self.children.iter().map(
-                        |c| c.get_mut()).collect();
+            let mm = self.m.borrow();
             let y_allocs = {
-                let y_reqs: Vec<&LReq> = child_refs.iter().map(|c| c.y_req()).collect();
-                flow_layout::alloc_y(&self.req.y_req,
-                    &self.alloc.y_alloc.without_position(),
-                    &y_reqs, self.y_spacing, &mut self.lines)
+                let child_reqs: Vec<Ref<ElementReq>> = mm.children.iter().map(|c| c.element_req()).collect();
+                let child_y_reqs: Vec<&LReq> = child_reqs.iter().map(|c| &c.y_req).collect();
+
+                let mut b_lines = self.m_lines.borrow_mut();
+                let mut lines: &mut Vec<flow_layout::FlowLine> = &mut (*b_lines);
+                flow_layout::alloc_y(&mm.req.y_req,
+                        &mm.alloc.y_alloc.without_position(),
+                        &child_y_reqs, mm.y_spacing, lines)
             };
-            for c in child_refs.iter_mut().zip(y_allocs.iter()) {
+            for c in mm.children.iter().zip(y_allocs.iter()) {
                 c.0.element_update_y_alloc(c.1);
             }
         }
@@ -107,11 +125,7 @@ impl TElement for FlowElement {
 
 
 impl TContainerElement for FlowElement {
-    fn children<'a>(&'a self) -> &'a Vec<ElementRef> {
-        return &self.children;
-    }
-
-    fn children_mut<'a>(&'a mut self) -> &'a mut Vec<ElementRef> {
-        return &mut self.children;
+    fn children(&self) -> Ref<Vec<ElementRef>> {
+        return Ref::map(self.m.borrow(), |m| &m.children);
     }
 }

--- a/src/lib/lspace/elements/root_element.rs
+++ b/src/lib/lspace/elements/root_element.rs
@@ -1,6 +1,9 @@
 use cairo::Context;
 
+use std::cell::{RefCell, Ref};
+
 use layout::lalloc::LAlloc;
+use layout::lreq::LReq;
 use geom::bbox2::BBox2;
 
 use elements::element_layout::{ElementReq, ElementAlloc};
@@ -8,56 +11,76 @@ use elements::element::{TElement, ElementRef};
 use elements::container::TContainerElement;
 
 
-pub struct RootElement {
+struct RootElementMut {
     req: ElementReq,
     alloc: ElementAlloc,
     children: Vec<ElementRef>,
 }
 
+pub struct RootElement {
+    m: RefCell<RootElementMut>,
+}
+
 impl RootElement {
     pub fn new(child: ElementRef) -> RootElement {
-        return RootElement{req: ElementReq::new(), alloc: ElementAlloc::new(),
-                           children: vec![child]};
+        return RootElement{m: RefCell::new(RootElementMut{
+                                req: ElementReq::new(), alloc: ElementAlloc::new(),
+                                children: vec![child]})};
     }
 
-    pub fn root_requisition_x(&mut self) -> f64 {
+    pub fn root_requisition_x(&self) -> f64 {
         self.update_x_req();
-        return self.req.x_req.size().size();
+        return self.m.borrow().req.x_req.size().size();
     }
 
-    pub fn root_allocate_x(&mut self, width: f64) {
-        self.alloc.x_alloc = LAlloc::new_from_req_in_avail_size(&self.req.x_req, 0.0, width);
+    pub fn root_allocate_x(&self, width: f64) {
+        // The following line of code would make sense in other languages:
+        //
+        //    self.m.borrow_mut().alloc.x_alloc =
+        //          LAlloc::new_from_req_in_avail_size(&self.m.borrow().req.x_req, 0.0, width);
+        //
+        // The mutable borrow for the assignment could only be taken out after the value has been
+        // computed; since the immutable borrow is only required during the computation, surely
+        // it could expire before the assignment starts, but alas, we have to do the following in
+        // order to hand-hold rust to make sure things go in and out of scope at the right time...
+
+        let x_alloc = {LAlloc::new_from_req_in_avail_size(&self.m.borrow().req.x_req, 0.0, width)};
+        self.m.borrow_mut().alloc.x_alloc = x_alloc;
+
         self.allocate_x();
     }
 
-    pub fn root_requisition_y(&mut self) -> f64 {
+    pub fn root_requisition_y(&self) -> f64 {
         self.update_y_req();
-        return self.req.y_req.size().size();
+        return self.m.borrow().req.y_req.size().size();
     }
 
-    pub fn root_allocate_y(&mut self, height: f64) {
-        self.alloc.y_alloc = LAlloc::new_from_req_in_avail_size(&self.req.y_req, 0.0, height);
+    pub fn root_allocate_y(&self, height: f64) {
+        let y_alloc = LAlloc::new_from_req_in_avail_size(&self.m.borrow().req.y_req, 0.0, height);
+        self.m.borrow_mut().alloc.y_alloc = y_alloc;
+
         self.allocate_y();
     }
 }
 
 impl TElement for RootElement {
-    fn element_req(&self) -> &ElementReq {
-        return &self.req;
+    fn element_req(&self) -> Ref<ElementReq> {
+        return Ref::map(self.m.borrow(), |m| &m.req);
     }
 
-    fn element_alloc(&self) -> &ElementAlloc {
-        return &self.alloc;
+    fn element_alloc(&self) -> Ref<ElementAlloc> {
+        return Ref::map(self.m.borrow(), |m| &m.alloc);
     }
 
     /// Update element X allocation
-    fn element_update_x_alloc(&mut self, x_alloc: &LAlloc) {
-        self.alloc.x_alloc.clone_from(x_alloc);
+    fn element_update_x_alloc(&self, x_alloc: &LAlloc) {
+        self.m.borrow_mut().alloc.x_alloc.clone_from(x_alloc);
     }
     /// Update element Y allocation
-    fn element_update_y_alloc(&mut self, y_alloc: &LAlloc) {
-        self.alloc.y_alloc.clone_from(y_alloc);
+    fn element_update_y_alloc(&self, y_alloc: &LAlloc) {
+        self.m.borrow_mut().alloc.y_alloc.clone_from(y_alloc);
     }
+
 
     fn draw(&self, cairo_ctx: &Context, visible_region: &BBox2) {
         self.draw_self(cairo_ctx, visible_region);
@@ -65,34 +88,40 @@ impl TElement for RootElement {
     }
 
 
-    fn update_x_req(&mut self) {
+    fn update_x_req(&self) {
         self.update_children_x_req();
-        self.req.x_req = self.children[0].get().x_req().clone();
+        let mut mm = self.m.borrow_mut();
+        let x_req: LReq = {mm.children[0].element_req().x_req.clone()};
+        mm.req.x_req = x_req;
     }
 
-    fn allocate_x(&mut self) {
-        self.children[0].get_mut().element_update_x_alloc(&self.alloc.x_alloc);
+    fn allocate_x(&self) {
+        {
+            let mm = self.m.borrow();
+            mm.children[0].element_update_x_alloc(&mm.alloc.x_alloc);
+        }
         self.allocate_children_x();
     }
 
-    fn update_y_req(&mut self) {
+    fn update_y_req(&self) {
         self.update_children_y_req();
-        self.req.y_req = self.children[0].get().y_req().clone();
+        let mut mm = self.m.borrow_mut();
+        let y_req: LReq = {mm.children[0].element_req().y_req.clone()};
+        mm.req.y_req = y_req;
     }
 
-    fn allocate_y(&mut self) {
-        self.children[0].get_mut().element_update_y_alloc(&self.alloc.y_alloc);
+    fn allocate_y(&self) {
+        {
+            let mm = self.m.borrow();
+            mm.children[0].element_update_y_alloc(&mm.alloc.y_alloc);
+        }
         self.allocate_children_y();
     }
 }
 
 impl TContainerElement for RootElement {
-    fn children<'a>(&'a self) -> &'a Vec<ElementRef> {
-        return &self.children;
-    }
-
-    fn children_mut<'a>(&'a mut self) -> &'a mut Vec<ElementRef> {
-        return &mut self.children;
+    fn children(&self) -> Ref<Vec<ElementRef>> {
+        return Ref::map(self.m.borrow(), |m| &m.children);
     }
 }
 

--- a/src/lib/lspace/elements/row.rs
+++ b/src/lib/lspace/elements/row.rs
@@ -1,6 +1,6 @@
 use cairo::Context;
 
-use std::cell::{Ref, RefMut};
+use std::cell::{RefCell, Ref};
 
 use layout::lreq::LReq;
 use layout::lalloc::LAlloc;
@@ -8,42 +8,47 @@ use layout::horizontal_layout;
 use geom::bbox2::BBox2;
 
 use elements::element_layout::{ElementReq, ElementAlloc};
-use elements::element::{TElement, ElementRef, ElemBorrow, ElemBorrowMut};
+use elements::element::{TElement, ElementRef};
 use elements::container::TContainerElement;
 
 
-pub struct RowElement {
+struct RowElementMut {
     req: ElementReq,
     alloc: ElementAlloc,
     children: Vec<ElementRef>,
     x_spacing: f64,
 }
 
+pub struct RowElement {
+    m: RefCell<RowElementMut>,
+}
+
 
 impl RowElement {
     pub fn new(children: Vec<ElementRef>, x_spacing: f64) -> RowElement {
-        return RowElement{req: ElementReq::new(), alloc: ElementAlloc::new(), children: children,
-                          x_spacing: x_spacing};
+        return RowElement{m: RefCell::new(RowElementMut{
+                            req: ElementReq::new(), alloc: ElementAlloc::new(),
+                            children: children, x_spacing: x_spacing})};
     }
 }
 
 
 impl TElement for RowElement {
-    fn element_req(&self) -> &ElementReq {
-        return &self.req;
+    fn element_req(&self) -> Ref<ElementReq> {
+        return Ref::map(self.m.borrow(), |m| &m.req);
     }
 
-    fn element_alloc(&self) -> &ElementAlloc {
-        return &self.alloc;
+    fn element_alloc(&self) -> Ref<ElementAlloc> {
+        return Ref::map(self.m.borrow(), |m| &m.alloc);
     }
 
     /// Update element X allocation
-    fn element_update_x_alloc(&mut self, x_alloc: &LAlloc) {
-        self.alloc.x_alloc.clone_from(x_alloc);
+    fn element_update_x_alloc(&self, x_alloc: &LAlloc) {
+        self.m.borrow_mut().alloc.x_alloc.clone_from(x_alloc);
     }
     /// Update element Y allocation
-    fn element_update_y_alloc(&mut self, y_alloc: &LAlloc) {
-        self.alloc.y_alloc.clone_from(y_alloc);
+    fn element_update_y_alloc(&self, y_alloc: &LAlloc) {
+        self.m.borrow_mut().alloc.y_alloc.clone_from(y_alloc);
     }
 
     fn draw(&self, cairo_ctx: &Context, visible_region: &BBox2) {
@@ -51,48 +56,57 @@ impl TElement for RowElement {
         self.draw_children(cairo_ctx, visible_region);
     }
 
-    fn update_x_req(&mut self) {
+    fn update_x_req(&self) {
         self.update_children_x_req();
-        let child_refs: Vec<ElemBorrow> = self.children.iter().map(|c| c.get()).collect();
-        let child_x_reqs: Vec<&LReq> = child_refs.iter().map(|c| c.x_req()).collect();
-        self.req.x_req = horizontal_layout::requisition_x(&child_x_reqs, self.x_spacing);
+        let mut mm = self.m.borrow_mut();
+        let x_req = {
+            let child_reqs: Vec<Ref<ElementReq>> = mm.children.iter().map(|c| c.element_req()).collect();
+            let child_x_reqs: Vec<&LReq> = child_reqs.iter().map(|c| &c.x_req).collect();
+            horizontal_layout::requisition_x(&child_x_reqs, mm.x_spacing)
+        };
+        mm.req.x_req = x_req;
     }
 
-    fn allocate_x(&mut self) {
+    fn allocate_x(&self) {
         {
-            let mut child_refs: Vec<ElemBorrowMut> = self.children.iter().map(
-                    |c| c.get_mut()).collect();
+            let mm = self.m.borrow();
             let x_allocs = {
-                let mut x_reqs: Vec<&LReq> = child_refs.iter().map(|c| c.x_req()).collect();
-                horizontal_layout::alloc_x(&self.req.x_req,
-                                           &self.alloc.x_alloc.without_position(), &mut x_reqs,
-                                           self.x_spacing)
+                let child_reqs: Vec<Ref<ElementReq>> = mm.children.iter().map(|c| c.element_req()).collect();
+                let child_x_reqs: Vec<&LReq> = child_reqs.iter().map(|c| &c.x_req).collect();
+
+                horizontal_layout::alloc_x(&mm.req.x_req,
+                                                          &mm.alloc.x_alloc.without_position(), &child_x_reqs,
+                                                          mm.x_spacing)
             };
-            for c in child_refs.iter_mut().zip(x_allocs.iter()) {
+            for c in mm.children.iter().zip(x_allocs.iter()) {
                 c.0.element_update_x_alloc(c.1);
             }
         }
         self.allocate_children_x();
     }
 
-    fn update_y_req(&mut self) {
+    fn update_y_req(&self) {
         self.update_children_y_req();
-        let child_refs: Vec<ElemBorrow> = self.children.iter().map(|c| c.get()).collect();
-        let child_y_reqs: Vec<&LReq> = child_refs.iter().map(|c| c.y_req()).collect();
-        self.req.y_req = horizontal_layout::requisition_y(&child_y_reqs);
+        let mut mm = self.m.borrow_mut();
+        let y_req = {
+            let child_reqs: Vec<Ref<ElementReq>> = mm.children.iter().map(|c| c.element_req()).collect();
+            let child_y_reqs: Vec<&LReq> = child_reqs.iter().map(|c| &c.y_req).collect();
+            horizontal_layout::requisition_y(&child_y_reqs)
+        };
+        mm.req.y_req = y_req;
     }
 
-    fn allocate_y(&mut self) {
+    fn allocate_y(&self) {
         {
-            let mut child_refs: Vec<ElemBorrowMut> = self.children.iter().map(
-                        |c| c.get_mut()).collect();
+            let mm = self.m.borrow();
             let y_allocs = {
-                let y_reqs: Vec<&LReq> = child_refs.iter().map(|c| c.y_req()).collect();
-                horizontal_layout::alloc_y(&self.req.y_req,
-                                           &self.alloc.y_alloc.without_position(),
-                                           &y_reqs)
+                let child_reqs: Vec<Ref<ElementReq>> = mm.children.iter().map(|c| c.element_req()).collect();
+                let child_y_reqs: Vec<&LReq> = child_reqs.iter().map(|c| &c.y_req).collect();
+
+                horizontal_layout::alloc_y(&mm.req.y_req, &mm.alloc.y_alloc.without_position(),
+                                                          &child_y_reqs)
             };
-            for c in child_refs.iter_mut().zip(y_allocs.iter()) {
+            for c in mm.children.iter().zip(y_allocs.iter()) {
                 c.0.element_update_y_alloc(c.1);
             }
         }
@@ -102,11 +116,7 @@ impl TElement for RowElement {
 
 
 impl TContainerElement for RowElement {
-    fn children<'a>(&'a self) -> &'a Vec<ElementRef> {
-        return &self.children;
-    }
-
-    fn children_mut<'a>(&'a mut self) -> &'a mut Vec<ElementRef> {
-        return &mut self.children;
+    fn children(&self) -> Ref<Vec<ElementRef>> {
+        return Ref::map(self.m.borrow(), |m| &m.children);
     }
 }

--- a/src/lib/lspace/layout/flow_layout.rs
+++ b/src/lib/lspace/layout/flow_layout.rs
@@ -11,6 +11,7 @@ pub enum FlowIndent {
 }
 
 
+#[derive(Debug, PartialEq, Copy, Clone)]
 pub struct FlowLine {
     y_req: LReq,
     pos_x_in_parent: f64,

--- a/src/lib/lspace/mod.rs
+++ b/src/lib/lspace/mod.rs
@@ -1,5 +1,6 @@
 #![feature(test)]
 #![feature(convert)]
+#![feature(cell_extras)]
 
 extern crate cairo;
 extern crate cairo_sys;

--- a/src/lib/lspace/pres/primitive.rs
+++ b/src/lib/lspace/pres/primitive.rs
@@ -22,7 +22,7 @@ impl TPres for Text {
     fn build(&self, pres_ctx: &PresBuildCtx) -> ElementRef {
         let elem = text_element::TextElement::new(self.text.clone(), self.style.clone(),
                                                   pres_ctx.cairo_ctx, &pres_ctx.elem_ctx);
-        return ElementRef::new(elem);
+        return Rc::new(elem);
     }
 }
 
@@ -41,7 +41,7 @@ impl TPres for Column {
     fn build(&self, pres_ctx: &PresBuildCtx) -> ElementRef {
         let child_elems = self.children.iter().map(|p| p.build(pres_ctx)).collect();
         let elem = column::ColumnElement::new(child_elems, 0.0);
-        return ElementRef::new(elem);
+        return Rc::new(elem);
     }
 }
 
@@ -60,7 +60,7 @@ impl TPres for Row {
     fn build(&self, pres_ctx: &PresBuildCtx) -> ElementRef {
         let child_elems = self.children.iter().map(|p| p.build(pres_ctx)).collect();
         let elem = row::RowElement::new(child_elems, 0.0);
-        return ElementRef::new(elem);
+        return Rc::new(elem);
     }
 }
 
@@ -79,7 +79,7 @@ impl TPres for Flow {
     fn build(&self, pres_ctx: &PresBuildCtx) -> ElementRef {
         let child_elems = self.children.iter().map(|p| p.build(pres_ctx)).collect();
         let elem = flow::FlowElement::new(child_elems, 0.0, 0.0, flow_layout::FlowIndent::NoIndent);
-        return ElementRef::new(elem);
+        return Rc::new(elem);
     }
 }
 


### PR DESCRIPTION
Modified element definitions so that they use interior mutability.
Element references are now `Rc<TElement>` rather than `Rc<RefCell<Box<TElement>>>`.
Mutable element fields within element structures are now guarded by `RefCell`.
This does result in changes to the `TElement` API, which `Ref<T>` being returned instead of `&T`.
