### PR TITLE
Initial development of element type specific behaviour API.

### DIFF
--- a/src/lib/lspace/elements/bin.rs
+++ b/src/lib/lspace/elements/bin.rs
@@ -1,0 +1,10 @@
+use std::cell::Ref;
+
+use elements::element::ElementRef;
+use elements::container::TContainerElement;
+
+pub trait TBinElement : TContainerElement {
+    fn get_child(&self) -> Option<Ref<ElementRef>>;
+    fn set_child(&self, self_ref: &ElementRef, child: ElementRef);
+    fn clear_child(&self);
+}

--- a/src/lib/lspace/elements/column.rs
+++ b/src/lib/lspace/elements/column.rs
@@ -10,6 +10,9 @@ use geom::bbox2::BBox2;
 use elements::element_layout::{ElementReq, ElementAlloc};
 use elements::element::{TElement, ElementRef};
 use elements::container::TContainerElement;
+use elements::bin::{TBinElement};
+use elements::container_sequence::{TContainerSequenceElement};
+use elements::root_element::{TRootElement};
 
 
 struct ColumnElementMut {
@@ -25,15 +28,33 @@ pub struct ColumnElement {
 
 
 impl ColumnElement {
-    pub fn new(children: Vec<ElementRef>, y_spacing: f64) -> ColumnElement {
+    pub fn new(y_spacing: f64) -> ColumnElement {
         return ColumnElement{m: RefCell::new(ColumnElementMut{
                                 req: ElementReq::new(), alloc: ElementAlloc::new(),
-                                children: children, y_spacing: y_spacing})};
+                                children: Vec::new(), y_spacing: y_spacing})};
     }
 }
 
 
 impl TElement for ColumnElement {
+    /// Interface acquisition
+    fn as_container(&self) -> Option<&TContainerElement> {
+        return Some(self);
+    }
+
+    fn as_bin(&self) -> Option<&TBinElement> {
+        return None;
+    }
+
+    fn as_container_sequence(&self) -> Option<&TContainerSequenceElement> {
+        return Some(self);
+    }
+
+    fn as_root_element(&self) -> Option<&TRootElement> {
+        return None;
+    }
+
+
     fn element_req(&self) -> Ref<ElementReq> {
         return Ref::map(self.m.borrow(), |m| &m.req);
     }
@@ -116,5 +137,17 @@ impl TElement for ColumnElement {
 impl TContainerElement for ColumnElement {
     fn children(&self) -> Ref<Vec<ElementRef>> {
         return Ref::map(self.m.borrow(), |m| &m.children);
+    }
+}
+
+
+impl TContainerSequenceElement for ColumnElement {
+    fn get_children(&self) -> Ref<Vec<ElementRef>> {
+        return Ref::map(self.m.borrow(), |m| &m.children);
+    }
+
+    fn set_children(&self, self_ref: &ElementRef, children: &Vec<ElementRef>) {
+        let mut mm = self.m.borrow_mut();
+        mm.children.clone_from(children);
     }
 }

--- a/src/lib/lspace/elements/container_sequence.rs
+++ b/src/lib/lspace/elements/container_sequence.rs
@@ -1,0 +1,9 @@
+use std::cell::Ref;
+
+use elements::element::ElementRef;
+use elements::container::TContainerElement;
+
+pub trait TContainerSequenceElement : TContainerElement {
+    fn get_children(&self) -> Ref<Vec<ElementRef>>;
+    fn set_children(&self, self_ref: &ElementRef, children: &Vec<ElementRef>);
+}

--- a/src/lib/lspace/elements/element.rs
+++ b/src/lib/lspace/elements/element.rs
@@ -8,12 +8,26 @@ use layout::lalloc::LAlloc;
 use geom::bbox2::BBox2;
 
 use elements::element_layout::{ElementReq, ElementAlloc};
+use elements::container::{TContainerElement};
+use elements::bin::{TBinElement};
+use elements::container_sequence::{TContainerSequenceElement};
+use elements::root_element::{TRootElement};
 
 
 pub type ElementRef = Rc<TElement>;
 
+pub fn elem_as_ref<T: TElement + 'static>(x: T) -> ElementRef {
+    return Rc::new(x);
+}
+
 
 pub trait TElement {
+    /// Interface acquisition
+    fn as_container(&self) -> Option<&TContainerElement>;
+    fn as_bin(&self) -> Option<&TBinElement>;
+    fn as_container_sequence(&self) -> Option<&TContainerSequenceElement>;
+    fn as_root_element(&self) -> Option<&TRootElement>;
+
     /// Acquire reference to the element layout requisition
     fn element_req(&self) -> Ref<ElementReq>;
     /// Acquire reference to the element layout allocation

--- a/src/lib/lspace/elements/flow.rs
+++ b/src/lib/lspace/elements/flow.rs
@@ -10,6 +10,9 @@ use geom::bbox2::BBox2;
 use elements::element_layout::{ElementReq, ElementAlloc};
 use elements::element::{TElement, ElementRef};
 use elements::container::TContainerElement;
+use elements::bin::{TBinElement};
+use elements::container_sequence::{TContainerSequenceElement};
+use elements::root_element::{TRootElement};
 
 
 pub struct FlowElementMut {
@@ -28,16 +31,34 @@ pub struct FlowElement {
 }
 
 impl FlowElement {
-    pub fn new(children: Vec<ElementRef>, x_spacing: f64, y_spacing: f64,
+    pub fn new(x_spacing: f64, y_spacing: f64,
                indentation: flow_layout::FlowIndent) -> FlowElement {
         return FlowElement{m: RefCell::new(FlowElementMut{
                                 req: ElementReq::new(), alloc: ElementAlloc::new(),
-                                children: children, x_spacing: x_spacing, y_spacing: y_spacing,
+                                children: Vec::new(), x_spacing: x_spacing, y_spacing: y_spacing,
                                 indentation: indentation}), m_lines: RefCell::new(Vec::new())};
     }
 }
 
 impl TElement for FlowElement {
+    /// Interface acquisition
+    fn as_container(&self) -> Option<&TContainerElement> {
+        return Some(self);
+    }
+
+    fn as_bin(&self) -> Option<&TBinElement> {
+        return None;
+    }
+
+    fn as_container_sequence(&self) -> Option<&TContainerSequenceElement> {
+        return Some(self);
+    }
+
+    fn as_root_element(&self) -> Option<&TRootElement> {
+        return None;
+    }
+
+
     fn element_req(&self) -> Ref<ElementReq> {
         return Ref::map(self.m.borrow(), |m| &m.req);
     }
@@ -126,5 +147,17 @@ impl TElement for FlowElement {
 impl TContainerElement for FlowElement {
     fn children(&self) -> Ref<Vec<ElementRef>> {
         return Ref::map(self.m.borrow(), |m| &m.children);
+    }
+}
+
+
+impl TContainerSequenceElement for FlowElement {
+    fn get_children(&self) -> Ref<Vec<ElementRef>> {
+        return Ref::map(self.m.borrow(), |m| &m.children);
+    }
+
+    fn set_children(&self, self_ref: &ElementRef, children: &Vec<ElementRef>) {
+        let mut mm = self.m.borrow_mut();
+        mm.children.clone_from(children);
     }
 }

--- a/src/lib/lspace/elements/mod.rs
+++ b/src/lib/lspace/elements/mod.rs
@@ -2,6 +2,8 @@ pub mod element_ctx;
 pub mod element_layout;
 pub mod element;
 pub mod container;
+pub mod bin;
+pub mod container_sequence;
 pub mod text_element;
 pub mod flow;
 pub mod column;

--- a/src/lib/lspace/elements/root_element.rs
+++ b/src/lib/lspace/elements/root_element.rs
@@ -9,6 +9,17 @@ use geom::bbox2::BBox2;
 use elements::element_layout::{ElementReq, ElementAlloc};
 use elements::element::{TElement, ElementRef};
 use elements::container::TContainerElement;
+use elements::bin::TBinElement;
+use elements::container_sequence::{TContainerSequenceElement};
+
+
+pub trait TRootElement : TBinElement {
+    fn root_requisition_x(&self) -> f64;
+    fn root_allocate_x(&self, width: f64);
+    fn root_requisition_y(&self) -> f64;
+
+    fn root_allocate_y(&self, height: f64);
+}
 
 
 struct RootElementMut {
@@ -22,47 +33,32 @@ pub struct RootElement {
 }
 
 impl RootElement {
-    pub fn new(child: ElementRef) -> RootElement {
+    pub fn new() -> RootElement {
         return RootElement{m: RefCell::new(RootElementMut{
-                                req: ElementReq::new(), alloc: ElementAlloc::new(),
-                                children: vec![child]})};
-    }
-
-    pub fn root_requisition_x(&self) -> f64 {
-        self.update_x_req();
-        return self.m.borrow().req.x_req.size().size();
-    }
-
-    pub fn root_allocate_x(&self, width: f64) {
-        // The following line of code would make sense in other languages:
-        //
-        //    self.m.borrow_mut().alloc.x_alloc =
-        //          LAlloc::new_from_req_in_avail_size(&self.m.borrow().req.x_req, 0.0, width);
-        //
-        // The mutable borrow for the assignment could only be taken out after the value has been
-        // computed; since the immutable borrow is only required during the computation, surely
-        // it could expire before the assignment starts, but alas, we have to do the following in
-        // order to hand-hold rust to make sure things go in and out of scope at the right time...
-        let x_alloc = LAlloc::new_from_req_in_avail_size(&self.m.borrow().req.x_req, 0.0, width);
-        self.m.borrow_mut().alloc.x_alloc = x_alloc;
-
-        self.allocate_x();
-    }
-
-    pub fn root_requisition_y(&self) -> f64 {
-        self.update_y_req();
-        return self.m.borrow().req.y_req.size().size();
-    }
-
-    pub fn root_allocate_y(&self, height: f64) {
-        let y_alloc = LAlloc::new_from_req_in_avail_size(&self.m.borrow().req.y_req, 0.0, height);
-        self.m.borrow_mut().alloc.y_alloc = y_alloc;
-
-        self.allocate_y();
+            req: ElementReq::new(), alloc: ElementAlloc::new(),
+            children: Vec::new()})};
     }
 }
 
 impl TElement for RootElement {
+    /// Interface acquisition
+    fn as_container(&self) -> Option<&TContainerElement> {
+        return Some(self);
+    }
+
+    fn as_bin(&self) -> Option<&TBinElement> {
+        return Some(self);
+    }
+
+    fn as_container_sequence(&self) -> Option<&TContainerSequenceElement> {
+        return None
+    }
+
+    fn as_root_element(&self) -> Option<&TRootElement> {
+        return Some(self);
+    }
+
+
     fn element_req(&self) -> Ref<ElementReq> {
         return Ref::map(self.m.borrow(), |m| &m.req);
     }
@@ -123,4 +119,57 @@ impl TContainerElement for RootElement {
         return Ref::map(self.m.borrow(), |m| &m.children);
     }
 }
+
+impl TBinElement for RootElement {
+    fn get_child(&self) -> Option<Ref<ElementRef>> {
+        let mm = self.m.borrow();
+        let n = mm.children.len();
+        assert!(n < 2);
+        return if n == 0 {None} else {Some(Ref::map(mm, |m| &m.children[0]))};
+    }
+
+    fn set_child(&self, self_ref: &ElementRef, child: ElementRef) {
+        let mut mm = self.m.borrow_mut();
+        if mm.children.len() == 0 {
+            mm.children.push(child);
+        }
+        else {
+            mm.children[0] = child;
+        }
+    }
+
+    fn clear_child(&self) {
+        let mut mm = self.m.borrow_mut();
+        mm.children.clear();
+    }
+}
+
+impl TRootElement for RootElement {
+    fn root_requisition_x(&self) -> f64 {
+        self.update_x_req();
+        return self.m.borrow().req.x_req.size().size();
+    }
+
+    fn root_allocate_x(&self, width: f64) {
+        // Need to assign to local variable first, then mutate value to ensure that the dynamic
+        // borrows don't overlap
+        let x_alloc = LAlloc::new_from_req_in_avail_size(&self.m.borrow().req.x_req, 0.0, width);
+        self.m.borrow_mut().alloc.x_alloc = x_alloc;
+
+        self.allocate_x();
+    }
+
+    fn root_requisition_y(&self) -> f64 {
+        self.update_y_req();
+        return self.m.borrow().req.y_req.size().size();
+    }
+
+    fn root_allocate_y(&self, height: f64) {
+        let y_alloc = LAlloc::new_from_req_in_avail_size(&self.m.borrow().req.y_req, 0.0, height);
+        self.m.borrow_mut().alloc.y_alloc = y_alloc;
+
+        self.allocate_y();
+    }
+}
+
 

--- a/src/lib/lspace/elements/row.rs
+++ b/src/lib/lspace/elements/row.rs
@@ -10,6 +10,9 @@ use geom::bbox2::BBox2;
 use elements::element_layout::{ElementReq, ElementAlloc};
 use elements::element::{TElement, ElementRef};
 use elements::container::TContainerElement;
+use elements::bin::{TBinElement};
+use elements::container_sequence::{TContainerSequenceElement};
+use elements::root_element::{TRootElement};
 
 
 struct RowElementMut {
@@ -25,15 +28,33 @@ pub struct RowElement {
 
 
 impl RowElement {
-    pub fn new(children: Vec<ElementRef>, x_spacing: f64) -> RowElement {
+    pub fn new(x_spacing: f64) -> RowElement {
         return RowElement{m: RefCell::new(RowElementMut{
                             req: ElementReq::new(), alloc: ElementAlloc::new(),
-                            children: children, x_spacing: x_spacing})};
+                            children: Vec::new(), x_spacing: x_spacing})};
     }
 }
 
 
 impl TElement for RowElement {
+    /// Interface acquisition
+    fn as_container(&self) -> Option<&TContainerElement> {
+        return Some(self);
+    }
+
+    fn as_bin(&self) -> Option<&TBinElement> {
+        return None;
+    }
+
+    fn as_container_sequence(&self) -> Option<&TContainerSequenceElement> {
+        return Some(self);
+    }
+
+    fn as_root_element(&self) -> Option<&TRootElement> {
+        return None;
+    }
+
+
     fn element_req(&self) -> Ref<ElementReq> {
         return Ref::map(self.m.borrow(), |m| &m.req);
     }
@@ -115,5 +136,17 @@ impl TElement for RowElement {
 impl TContainerElement for RowElement {
     fn children(&self) -> Ref<Vec<ElementRef>> {
         return Ref::map(self.m.borrow(), |m| &m.children);
+    }
+}
+
+
+impl TContainerSequenceElement for RowElement {
+    fn get_children(&self) -> Ref<Vec<ElementRef>> {
+        return Ref::map(self.m.borrow(), |m| &m.children);
+    }
+
+    fn set_children(&self, self_ref: &ElementRef, children: &Vec<ElementRef>) {
+        let mut mm = self.m.borrow_mut();
+        mm.children.clone_from(children);
     }
 }

--- a/src/lib/lspace/elements/text_element.rs
+++ b/src/lib/lspace/elements/text_element.rs
@@ -13,6 +13,10 @@ use geom::colour::{Colour, BLACK};
 use elements::element_layout::{ElementReq, ElementAlloc};
 use elements::element_ctx::{ElementContext};
 use elements::element::{TElement};
+use elements::container::{TContainerElement};
+use elements::bin::{TBinElement};
+use elements::container_sequence::{TContainerSequenceElement};
+use elements::root_element::{TRootElement};
 
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
@@ -127,6 +131,24 @@ impl TextElement {
 }
 
 impl TElement for TextElement {
+    /// Interface acquisition
+    fn as_container(&self) -> Option<&TContainerElement> {
+        return None;
+    }
+
+    fn as_bin(&self) -> Option<&TBinElement> {
+        return None
+    }
+
+    fn as_container_sequence(&self) -> Option<&TContainerSequenceElement> {
+        return None
+    }
+
+    fn as_root_element(&self) -> Option<&TRootElement> {
+        return None;
+    }
+
+
     fn element_req(&self) -> Ref<ElementReq> {
         return Ref::map(self.m.borrow(), |m| &(*m.req));
     }


### PR DESCRIPTION
Element type specific behaviour now accessed through trait acquisition methods defined on `TElement`.

Currently these consist of container behaviours that define methods for mutating container child lists.

Currently all element references are of type `ElementRef`, which is an alias for `Rc<TElement>`. The `TElement` trait provides the abstract base functionality common to all element types - in other words - not much. Some elements are containers and have child elements, others have different behaviour and features. The `as_*` methods defined on `TElement` introduced by this PR allow you to get interfaces to access the behaviour that is supported by an element.

The behaviours introduced in this PR allow you to gain access to the interfaces for generic containers, sequential containers, bin elements (container only one - optional - child) and the root element.

The approach offers functionality analogous to up-casting in a classic OO language, where a reference to an object of a base type is up-casted to a subclass that it implements.
