### PR TITLE
Element components refactor

### DIFF
--- a/src/lib/lspace/elements/bin.rs
+++ b/src/lib/lspace/elements/bin.rs
@@ -3,8 +3,59 @@ use std::cell::Ref;
 use elements::element::ElementRef;
 use elements::container::TContainerElement;
 
+/// Bin element trait; all bin elements should implement this and delegate implementation to
+/// same named methods defined in `BinElementMut` below.
 pub trait TBinElement : TContainerElement {
-    fn get_child(&self) -> Option<Ref<ElementRef>>;
+    fn get_child(&self) -> Option<ElementRef>;
     fn set_child(&self, self_ref: &ElementRef, child: ElementRef);
     fn clear_child(&self);
+}
+
+
+/// Bin element component, should be placed behind `RefCell` mutation barrier
+/// Manages child element
+pub struct BinComponentMut {
+    child: Option<[ElementRef; 1]>,
+}
+
+
+const NO_CHILDREN: [ElementRef; 0] = [];
+
+impl BinComponentMut {
+    pub fn new() -> BinComponentMut {
+        return BinComponentMut{child: None};
+    }
+
+    pub fn children(&self) -> &[ElementRef] {
+        return match self.child {
+            None => &NO_CHILDREN[..],
+            Some(ref ch) => &ch[..]
+        };
+    }
+
+    pub fn get_child(&self) -> Option<ElementRef> {
+        let child: Option<ElementRef> = match self.child {
+            None => None,
+            Some(ref ch) => Some(ch[0].clone()),
+        };
+        return child;
+    }
+
+    pub fn set_child(&mut self, self_ref: &ElementRef, child: ElementRef) {
+        match self.child {
+            None => {},
+            Some(ref ch) => ch[0].set_parent(None)
+        };
+        child.set_parent(Some(self_ref));
+        self.child = Some([child]);
+
+    }
+
+    pub fn clear_child(&mut self) {
+        match self.child {
+            None => {},
+            Some(ref ch) => ch[0].set_parent(None)
+        };
+        self.child = None;
+    }
 }

--- a/src/lib/lspace/elements/container.rs
+++ b/src/lib/lspace/elements/container.rs
@@ -9,7 +9,7 @@ use elements::element::{TElement, ElementRef};
 
 
 pub trait TContainerElement : TElement {
-    fn children(&self) -> Ref<Vec<ElementRef>>;
+    fn children(&self) -> Ref<[ElementRef]>;
 
     fn draw_children(&self, cairo_ctx: &Context, visible_region: &BBox2) {
         for child in self.children().iter() {

--- a/src/lib/lspace/elements/container_sequence.rs
+++ b/src/lib/lspace/elements/container_sequence.rs
@@ -3,7 +3,40 @@ use std::cell::Ref;
 use elements::element::ElementRef;
 use elements::container::TContainerElement;
 
+
 pub trait TContainerSequenceElement : TContainerElement {
     fn get_children(&self) -> Ref<Vec<ElementRef>>;
     fn set_children(&self, self_ref: &ElementRef, children: &Vec<ElementRef>);
 }
+
+
+/// Container sequence element component, should be placed behind `RefCell` mutation barrier
+/// Manages child elements
+pub struct ContainerSequenceComponentMut {
+    children: Vec<ElementRef>,
+}
+
+impl ContainerSequenceComponentMut {
+    pub fn new() -> ContainerSequenceComponentMut {
+        return ContainerSequenceComponentMut{children: Vec::new()};
+    }
+
+    pub fn children(&self) -> &[ElementRef] {
+        return &self.children[..];
+    }
+
+    pub fn get_children(&self) -> &Vec<ElementRef> {
+        return &self.children;
+    }
+
+    pub fn set_children(&mut self, self_ref: &ElementRef, children: &Vec<ElementRef>) {
+        for child in self.children.iter() {
+            child.set_parent(None);
+        }
+        for child in children {
+            child.set_parent(Some(self_ref));
+        }
+        self.children.clone_from(children);
+    }
+}
+

--- a/src/lib/lspace/elements/element.rs
+++ b/src/lib/lspace/elements/element.rs
@@ -28,6 +28,11 @@ pub trait TElement {
     fn as_container_sequence(&self) -> Option<&TContainerSequenceElement>;
     fn as_root_element(&self) -> Option<&TRootElement>;
 
+    /// Parent get and set methods
+    fn get_parent(&self) -> Option<ElementRef>;
+    fn set_parent(&self, p: Option<&ElementRef>);
+
+
     /// Acquire reference to the element layout requisition
     fn element_req(&self) -> Ref<ElementReq>;
     /// Acquire reference to the element layout allocation
@@ -36,26 +41,6 @@ pub trait TElement {
     fn element_update_x_alloc(&self, x_alloc: &LAlloc);
     /// Update element Y allocation
     fn element_update_y_alloc(&self, y_alloc: &LAlloc);
-
-    /// Acquire reference to element layout X requisition
-    fn x_req(&self) -> Ref<LReq> {
-        return Ref::map(self.element_req(), |r| &r.x_req);
-    }
-
-    /// Acquire reference to element layout X allocation
-    fn x_alloc(&self) -> Ref<LAlloc> {
-        return Ref::map(self.element_alloc(), |a| &a.x_alloc);
-    }
-
-    /// Acquire reference to element layout Y requisition
-    fn y_req(&self) -> Ref<LReq> {
-        return Ref::map(self.element_req(), |r| &r.y_req);
-    }
-
-    /// Acquire reference to element layout Y allocation
-    fn y_alloc(&self) -> Ref<LAlloc> {
-        return Ref::map(self.element_alloc(), |a| &a.y_alloc);
-    }
 
 
     /// Paint the element content that is contributed by the element itself, as opposed to child
@@ -77,4 +62,26 @@ pub trait TElement {
 
     /// Update layout: Y allocation
     fn allocate_y(&self);
+}
+
+
+pub struct ElementParentMut {
+    parent: Option<ElementRef>
+}
+
+impl ElementParentMut {
+    pub fn new() -> ElementParentMut {
+        return ElementParentMut{parent: None};
+    }
+
+    pub fn get(&self) -> Option<ElementRef> {
+        return self.parent.clone();
+    }
+
+    pub fn set(&mut self, p: Option<&ElementRef>) {
+        self.parent = match p {
+            None => None,
+            Some(pp) => Some(pp.clone())
+        };
+    }
 }

--- a/src/lib/lspace/elements/row.rs
+++ b/src/lib/lspace/elements/row.rs
@@ -8,17 +8,18 @@ use layout::horizontal_layout;
 use geom::bbox2::BBox2;
 
 use elements::element_layout::{ElementReq, ElementAlloc};
-use elements::element::{TElement, ElementRef};
+use elements::element::{TElement, ElementRef, ElementParentMut};
 use elements::container::TContainerElement;
 use elements::bin::{TBinElement};
-use elements::container_sequence::{TContainerSequenceElement};
+use elements::container_sequence::{TContainerSequenceElement, ContainerSequenceComponentMut};
 use elements::root_element::{TRootElement};
 
 
 struct RowElementMut {
+    parent: ElementParentMut,
     req: ElementReq,
     alloc: ElementAlloc,
-    children: Vec<ElementRef>,
+    container_seq: ContainerSequenceComponentMut,
     x_spacing: f64,
 }
 
@@ -30,8 +31,9 @@ pub struct RowElement {
 impl RowElement {
     pub fn new(x_spacing: f64) -> RowElement {
         return RowElement{m: RefCell::new(RowElementMut{
-                            req: ElementReq::new(), alloc: ElementAlloc::new(),
-                            children: Vec::new(), x_spacing: x_spacing})};
+                parent: ElementParentMut::new(),
+                req: ElementReq::new(), alloc: ElementAlloc::new(),
+                container_seq: ContainerSequenceComponentMut::new(), x_spacing: x_spacing})};
     }
 }
 
@@ -52,6 +54,16 @@ impl TElement for RowElement {
 
     fn as_root_element(&self) -> Option<&TRootElement> {
         return None;
+    }
+
+
+    /// Parent get and set methods
+    fn get_parent(&self) -> Option<ElementRef> {
+        return self.m.borrow().parent.get().clone();
+    }
+
+    fn set_parent(&self, p: Option<&ElementRef>) {
+        self.m.borrow_mut().parent.set(p);
     }
 
 
@@ -81,7 +93,8 @@ impl TElement for RowElement {
         self.update_children_x_req();
         let mut mm = self.m.borrow_mut();
         let x_req = {
-            let child_reqs: Vec<Ref<ElementReq>> = mm.children.iter().map(|c| c.element_req()).collect();
+            let child_reqs: Vec<Ref<ElementReq>> = mm.container_seq.get_children().iter().map(
+                    |c| c.element_req()).collect();
             let child_x_reqs: Vec<&LReq> = child_reqs.iter().map(|c| &c.x_req).collect();
             horizontal_layout::requisition_x(&child_x_reqs, mm.x_spacing)
         };
@@ -92,13 +105,14 @@ impl TElement for RowElement {
         let mm = self.m.borrow();
         let x_allocs;
         {
-            let child_reqs: Vec<Ref<ElementReq>> = mm.children.iter().map(|c| c.element_req()).collect();
+            let child_reqs: Vec<Ref<ElementReq>> = mm.container_seq.get_children().iter().map(
+                    |c| c.element_req()).collect();
             let child_x_reqs: Vec<&LReq> = child_reqs.iter().map(|c| &c.x_req).collect();
 
             x_allocs = horizontal_layout::alloc_x(&mm.req.x_req,
                   &mm.alloc.x_alloc.without_position(), &child_x_reqs, mm.x_spacing);
         }
-        for c in mm.children.iter().zip(x_allocs.iter()) {
+        for c in mm.container_seq.get_children().iter().zip(x_allocs.iter()) {
             c.0.element_update_x_alloc(c.1);
         }
         self.allocate_children_x();
@@ -108,7 +122,8 @@ impl TElement for RowElement {
         self.update_children_y_req();
         let mut mm = self.m.borrow_mut();
         let y_req = {
-            let child_reqs: Vec<Ref<ElementReq>> = mm.children.iter().map(|c| c.element_req()).collect();
+            let child_reqs: Vec<Ref<ElementReq>> = mm.container_seq.get_children().iter().map(
+                    |c| c.element_req()).collect();
             let child_y_reqs: Vec<&LReq> = child_reqs.iter().map(|c| &c.y_req).collect();
             horizontal_layout::requisition_y(&child_y_reqs)
         };
@@ -119,13 +134,14 @@ impl TElement for RowElement {
         let mm = self.m.borrow();
         let y_allocs;
         {
-            let child_reqs: Vec<Ref<ElementReq>> = mm.children.iter().map(|c| c.element_req()).collect();
+            let child_reqs: Vec<Ref<ElementReq>> = mm.container_seq.get_children().iter().map(
+                    |c| c.element_req()).collect();
             let child_y_reqs: Vec<&LReq> = child_reqs.iter().map(|c| &c.y_req).collect();
 
             y_allocs = horizontal_layout::alloc_y(&mm.req.y_req,
                   &mm.alloc.y_alloc.without_position(), &child_y_reqs);
         }
-        for c in mm.children.iter().zip(y_allocs.iter()) {
+        for c in mm.container_seq.get_children().iter().zip(y_allocs.iter()) {
             c.0.element_update_y_alloc(c.1);
         }
         self.allocate_children_y();
@@ -134,19 +150,18 @@ impl TElement for RowElement {
 
 
 impl TContainerElement for RowElement {
-    fn children(&self) -> Ref<Vec<ElementRef>> {
-        return Ref::map(self.m.borrow(), |m| &m.children);
+    fn children(&self) -> Ref<[ElementRef]> {
+        return Ref::map(self.m.borrow(), |m| m.container_seq.children());
     }
 }
 
 
 impl TContainerSequenceElement for RowElement {
     fn get_children(&self) -> Ref<Vec<ElementRef>> {
-        return Ref::map(self.m.borrow(), |m| &m.children);
+        return Ref::map(self.m.borrow(), |m| m.container_seq.get_children());
     }
 
     fn set_children(&self, self_ref: &ElementRef, children: &Vec<ElementRef>) {
-        let mut mm = self.m.borrow_mut();
-        mm.children.clone_from(children);
+        self.m.borrow_mut().container_seq.set_children(self_ref, children);
     }
 }

--- a/src/lib/lspace/elements/text_element.rs
+++ b/src/lib/lspace/elements/text_element.rs
@@ -12,7 +12,7 @@ use geom::bbox2::BBox2;
 use geom::colour::{Colour, BLACK};
 use elements::element_layout::{ElementReq, ElementAlloc};
 use elements::element_ctx::{ElementContext};
-use elements::element::{TElement};
+use elements::element::{TElement, ElementRef, ElementParentMut};
 use elements::container::{TContainerElement};
 use elements::bin::{TBinElement};
 use elements::container_sequence::{TContainerSequenceElement};
@@ -106,6 +106,7 @@ pub type TextReqKey = (String, TextWeight, TextSlant, i64, String);
 
 
 struct TextElementMut {
+    parent: ElementParentMut,
     req: Rc<ElementReq>,
     alloc: ElementAlloc,
     text: String,
@@ -123,6 +124,7 @@ impl TextElement {
         let req = elem_ctx.borrow_mut().text_shared_req(style.clone(), text.clone(), cairo_ctx);
         return TextElement{style: style,
                            m: RefCell::new(TextElementMut{
+                                parent: ElementParentMut::new(),
                                 req: req,
                                 alloc: ElementAlloc::new(),
                                 text: text}),
@@ -146,6 +148,17 @@ impl TElement for TextElement {
 
     fn as_root_element(&self) -> Option<&TRootElement> {
         return None;
+    }
+
+
+
+    /// Parent get and set methods
+    fn get_parent(&self) -> Option<ElementRef> {
+        return self.m.borrow().parent.get().clone();
+    }
+
+    fn set_parent(&self, p: Option<&ElementRef>) {
+        self.m.borrow_mut().parent.set(p);
     }
 
 


### PR DESCRIPTION
Implemented element components; structures that are used within element types that handle aspects of element behaviour.

There are 3 components so far:
- `ElementParentMut` manages the element->parent reference held by each element
- `BinComponentMut` manages the bin container -> child relationship/reference
- `ContainerSequenceComponentMut` manages the sequential container - children relatioships/references

This refactor moves functionality that is common to various element types into separate structures. The concrete element types define methods and delegate the implementation to the methods defined on the components.

This provides the general _shape_ that will be used for other elements and functionaltiy in the future.
