### PR TITLE
Modified layout algorithm to operate in an incremental fashion.

### DIFF
--- a/src/lib/lspace/elements/column.rs
+++ b/src/lib/lspace/elements/column.rs
@@ -1,6 +1,6 @@
 use cairo::Context;
 
-use std::cell::{RefCell, Ref};
+use std::cell::{RefCell, Ref, RefMut};
 
 use layout::lreq::LReq;
 use layout::lalloc::LAlloc;
@@ -56,7 +56,6 @@ impl TElement for ColumnElement {
         return None;
     }
 
-
     /// Parent get and set methods
     fn get_parent(&self) -> Option<ElementRef> {
         return self.m.borrow().parent.get().clone();
@@ -66,7 +65,7 @@ impl TElement for ColumnElement {
         self.m.borrow_mut().parent.set(p);
     }
 
-
+    /// Element layout structure acquisition
     fn element_req(&self) -> Ref<ElementReq> {
         return Ref::map(self.m.borrow(), |m| &m.req);
     }
@@ -75,77 +74,41 @@ impl TElement for ColumnElement {
         return Ref::map(self.m.borrow(), |m| &m.alloc);
     }
 
-    /// Update element X allocation
-    fn element_update_x_alloc(&self, x_alloc: &LAlloc) {
-        self.m.borrow_mut().alloc.x_alloc.clone_from(x_alloc);
-    }
-    /// Update element Y allocation
-    fn element_update_y_alloc(&self, y_alloc: &LAlloc) {
-        self.m.borrow_mut().alloc.y_alloc.clone_from(y_alloc);
+    fn element_alloc_mut(&self) -> RefMut<ElementAlloc> {
+        return RefMut::map(self.m.borrow_mut(), |m| &mut m.alloc);
     }
 
+    /// Update element X requisition
+    fn element_update_x_req(&self, x_req: &LReq) -> bool {
+        return self.m.borrow_mut().req.update_x_req(x_req);
+    }
 
+    /// Update element Y requisition
+    fn element_update_y_req(&self, y_req: &LReq) -> bool {
+        return self.m.borrow_mut().req.update_y_req(y_req);
+    }
+
+    /// Draw
     fn draw(&self, cairo_ctx: &Context, visible_region: &BBox2) {
         self.draw_self(cairo_ctx, visible_region);
         self.draw_children(cairo_ctx, visible_region);
     }
 
-    fn update_x_req(&self) {
-        self.update_children_x_req();
-        let mut mm = self.m.borrow_mut();
-        let x_req = {
-            let child_reqs: Vec<Ref<ElementReq>> = mm.container_seq.get_children().iter().map(
-                    |c| c.element_req()).collect();
-            let child_x_reqs: Vec<&LReq> = child_reqs.iter().map(|c| &c.x_req).collect();
-            vertical_layout::requisition_x(&child_x_reqs)
-        };
-        mm.req.x_req = x_req;
+    /// Update layout
+    fn update_x_req(&self) -> bool {
+        return self.container_update_x_req();
     }
 
-    fn allocate_x(&self) {
-        let mm = self.m.borrow();
-        let x_allocs;
-        {
-            let child_reqs: Vec<Ref<ElementReq>> = mm.container_seq.get_children().iter().map(
-                    |c| c.element_req()).collect();
-            let child_x_reqs: Vec<&LReq> = child_reqs.iter().map(|c| &c.x_req).collect();
-
-            x_allocs = vertical_layout::alloc_x(&mm.req.x_req,
-                    &mm.alloc.x_alloc.without_position(), &child_x_reqs);
-        }
-        for c in mm.container_seq.get_children().iter().zip(x_allocs.iter()) {
-            c.0.element_update_x_alloc(c.1);
-        }
-        self.allocate_children_x();
+    fn allocate_x(&self, x_alloc: &LAlloc) -> bool {
+        return self.container_allocate_x(x_alloc);
     }
 
-    fn update_y_req(&self) {
-        self.update_children_y_req();
-        let mut mm = self.m.borrow_mut();
-        let y_req = {
-            let child_reqs: Vec<Ref<ElementReq>> = mm.container_seq.get_children().iter().map(
-                    |c| c.element_req()).collect();
-            let child_y_reqs: Vec<&LReq> = child_reqs.iter().map(|c| &c.y_req).collect();
-            vertical_layout::requisition_y(&child_y_reqs, mm.y_spacing, None)
-        };
-        mm.req.y_req = y_req;
+    fn update_y_req(&self) -> bool {
+        return self.container_update_y_req();
     }
 
-    fn allocate_y(&self) {
-        let mm = self.m.borrow();
-        let y_allocs;
-        {
-            let child_reqs: Vec<Ref<ElementReq>> = mm.container_seq.get_children().iter().map(
-                    |c| c.element_req()).collect();
-            let child_y_reqs: Vec<&LReq> = child_reqs.iter().map(|c| &c.y_req).collect();
-
-            y_allocs = vertical_layout::alloc_y(&mm.req.y_req,
-                    &mm.alloc.y_alloc.without_position(), &child_y_reqs, mm.y_spacing, None);
-        }
-        for c in mm.container_seq.get_children().iter().zip(y_allocs.iter()) {
-            c.0.element_update_y_alloc(c.1);
-        }
-        self.allocate_children_y();
+    fn allocate_y(&self, y_alloc: &LAlloc) {
+        self.container_allocate_y(y_alloc);
     }
 }
 
@@ -153,6 +116,42 @@ impl TElement for ColumnElement {
 impl TContainerElement for ColumnElement {
     fn children(&self) -> Ref<[ElementRef]> {
         return Ref::map(self.m.borrow(), |m| m.container_seq.children());
+    }
+
+    fn compute_x_req(&self) -> LReq {
+        let mut mm = self.m.borrow_mut();
+        let child_reqs: Vec<Ref<ElementReq>> = mm.container_seq.get_children().iter().map(
+            |c| c.element_req()).collect();
+        let child_x_reqs: Vec<&LReq> = child_reqs.iter().map(|c| &c.x_req).collect();
+        return vertical_layout::requisition_x(&child_x_reqs);
+    }
+
+    fn compute_child_x_allocs(&self) -> Vec<LAlloc> {
+        let mut mm = self.m.borrow_mut();
+        let child_reqs: Vec<Ref<ElementReq>> = mm.container_seq.get_children().iter().map(
+            |c| c.element_req()).collect();
+        let child_x_reqs: Vec<&LReq> = child_reqs.iter().map(|c| &c.x_req).collect();
+
+        return vertical_layout::alloc_x(&mm.req.x_req,
+                                        &mm.alloc.x_alloc.without_position(), &child_x_reqs);
+    }
+
+    fn compute_y_req(&self) -> LReq {
+        let mut mm = self.m.borrow_mut();
+        let child_reqs: Vec<Ref<ElementReq>> = mm.container_seq.get_children().iter().map(
+            |c| c.element_req()).collect();
+        let child_y_reqs: Vec<&LReq> = child_reqs.iter().map(|c| &c.y_req).collect();
+        return vertical_layout::requisition_y(&child_y_reqs, mm.y_spacing, None);
+    }
+
+    fn compute_child_y_allocs(&self) -> Vec<LAlloc> {
+        let mut mm = self.m.borrow_mut();
+        let child_reqs: Vec<Ref<ElementReq>> = mm.container_seq.get_children().iter().map(
+            |c| c.element_req()).collect();
+        let child_y_reqs: Vec<&LReq> = child_reqs.iter().map(|c| &c.y_req).collect();
+
+        return vertical_layout::alloc_y(&mm.req.y_req,
+                                        &mm.alloc.y_alloc.without_position(), &child_y_reqs, mm.y_spacing, None);
     }
 }
 

--- a/src/lib/lspace/elements/container.rs
+++ b/src/lib/lspace/elements/container.rs
@@ -5,6 +5,9 @@ use std::cell::Ref;
 use geom::vector2::Vector2;
 use geom::bbox2::BBox2;
 
+use layout::lreq::LReq;
+use layout::lalloc::LAlloc;
+
 use elements::element::{TElement, ElementRef};
 
 
@@ -28,27 +31,106 @@ pub trait TContainerElement : TElement {
         }
     }
 
-    fn update_children_x_req(&self) {
+    fn update_children_x_req(&self) -> bool {
+        let mut changed: bool = false;
         for child in self.children().iter() {
-            child.update_x_req();
+            changed = changed | child.update_x_req();
+        }
+        return changed;
+    }
+
+    fn update_children_y_req(&self) -> bool {
+        let mut changed: bool = false;
+        for child in self.children().iter() {
+            changed = changed | child.update_y_req();
+        }
+        return changed;
+    }
+
+    fn allocate_children_x(&self, alloc_xs: &Vec<LAlloc>) -> bool {
+        let mut child_y_reqs_dirty: bool = false;
+        for c in self.children().iter().zip(alloc_xs) {
+            child_y_reqs_dirty = child_y_reqs_dirty | c.0.allocate_x(c.1);
+        }
+        return child_y_reqs_dirty;
+    }
+
+    fn allocate_children_y(&self, alloc_ys: &Vec<LAlloc>) {
+        for c in self.children().iter().zip(alloc_ys) {
+            c.0.allocate_y(c.1);
         }
     }
 
-    fn update_children_y_req(&self) {
-        for child in self.children().iter() {
-            child.update_y_req();
+    fn compute_x_req(&self) -> LReq;
+    fn compute_child_x_allocs(&self) -> Vec<LAlloc>;
+    fn compute_y_req(&self) -> LReq;
+    fn compute_child_y_allocs(&self) -> Vec<LAlloc>;
+
+    fn container_update_x_req(&self) -> bool {
+        if !self.element_alloc().is_x_req_update_required() {
+            return false;
         }
+        let children_changed = self.update_children_x_req();
+        let mut changed: bool = false;
+        if children_changed {
+            let x_req = self.compute_x_req();
+            changed = self.element_update_x_req(&x_req);
+        }
+        let mut alloc_mut = self.element_alloc_mut();
+        alloc_mut.x_req_updated();
+        if children_changed || changed {
+            alloc_mut.x_alloc_dirty();
+        }
+        return changed;
     }
 
-    fn allocate_children_x(&self) {
-        for child in self.children().iter() {
-            child.allocate_x();
+    fn container_allocate_x(&self, x_alloc: &LAlloc) -> bool {
+        let update_needed;
+        {
+            let mut elem_alloc = self.element_alloc_mut();
+            let changed = elem_alloc.update_x_alloc(x_alloc);
+            update_needed = changed | elem_alloc.is_x_alloc_update_required();
+            elem_alloc.x_alloc_updated();
         }
+        if !update_needed {
+            return false;
+        }
+        let x_allocs = self.compute_child_x_allocs();
+        let child_y_reqs_dirty = self.allocate_children_x(&x_allocs);
+        if child_y_reqs_dirty {
+            let mut elem_alloc = self.element_alloc_mut();
+            elem_alloc.y_req_dirty();
+            elem_alloc.y_alloc_dirty();
+        }
+        return child_y_reqs_dirty;
     }
 
-    fn allocate_children_y(&self) {
-        for child in self.children().iter() {
-            child.allocate_y();
+    fn container_update_y_req(&self) -> bool {
+        if !self.element_alloc().is_y_req_update_required() {
+            return false;
+        }
+        self.update_children_y_req();
+        let y_req = self.compute_y_req();
+        let changed = self.element_update_y_req(&y_req);
+        let mut alloc_mut = self.element_alloc_mut();
+        alloc_mut.y_req_updated();
+        if changed {
+            alloc_mut.y_alloc_dirty();
+        }
+        return changed;
+    }
+
+    fn container_allocate_y(&self, y_alloc: &LAlloc) {
+        let update_needed;
+        {
+            let mut elem_alloc = self.element_alloc_mut();
+            let changed = elem_alloc.update_y_alloc(y_alloc);
+            update_needed = changed | elem_alloc.is_y_alloc_update_required();
+            elem_alloc.y_alloc_updated();
+        }
+        if update_needed {
+            let y_allocs = self.compute_child_y_allocs();
+            self.allocate_children_y(&y_allocs);
         }
     }
 }

--- a/src/lib/lspace/elements/element.rs
+++ b/src/lib/lspace/elements/element.rs
@@ -1,7 +1,7 @@
 use cairo::Context;
 
 use std::rc::Rc;
-use std::cell::{RefCell, Ref};
+use std::cell::{RefCell, Ref, RefMut};
 
 use layout::lreq::LReq;
 use layout::lalloc::LAlloc;
@@ -32,16 +32,15 @@ pub trait TElement {
     fn get_parent(&self) -> Option<ElementRef>;
     fn set_parent(&self, p: Option<&ElementRef>);
 
-
     /// Acquire reference to the element layout requisition
     fn element_req(&self) -> Ref<ElementReq>;
     /// Acquire reference to the element layout allocation
     fn element_alloc(&self) -> Ref<ElementAlloc>;
-    /// Update element X allocation
-    fn element_update_x_alloc(&self, x_alloc: &LAlloc);
-    /// Update element Y allocation
-    fn element_update_y_alloc(&self, y_alloc: &LAlloc);
-
+    fn element_alloc_mut(&self) -> RefMut<ElementAlloc>;
+    /// Update element X requisition
+    fn element_update_x_req(&self, x_req: &LReq) -> bool;
+    /// Update element Y requisition
+    fn element_update_y_req(&self, y_req: &LReq) -> bool;
 
     /// Paint the element content that is contributed by the element itself, as opposed to child
     /// elements.
@@ -52,16 +51,16 @@ pub trait TElement {
     fn draw(&self, cairo_ctx: &Context, visible_region: &BBox2);
 
     /// Update layout: X requisition
-    fn update_x_req(&self);
+    fn update_x_req(&self) -> bool;
 
     /// Update layout: X allocation
-    fn allocate_x(&self);
+    fn allocate_x(&self, x_alloc: &LAlloc) -> bool;
 
     /// Update layout: Y requisition
-    fn update_y_req(&self);
+    fn update_y_req(&self) -> bool;
 
     /// Update layout: Y allocation
-    fn allocate_y(&self);
+    fn allocate_y(&self, y_alloc: &LAlloc);
 }
 
 

--- a/src/lib/lspace/elements/element_layout.rs
+++ b/src/lib/lspace/elements/element_layout.rs
@@ -2,6 +2,8 @@ use layout::lreq::LReq;
 use layout::lalloc::LAlloc;
 use geom::bbox2::BBox2;
 
+use elements::element::{TElement, ElementRef};
+
 const LAYOUT_FLAG_X_REQ_DIRTY: u8       = 0b0001;
 const LAYOUT_FLAG_Y_REQ_DIRTY: u8       = 0b0010;
 const LAYOUT_FLAG_X_ALLOC_DIRTY: u8     = 0b0100;
@@ -23,6 +25,21 @@ impl ElementReq {
     pub fn new_from_reqs(x_req: LReq, y_req: LReq) -> ElementReq {
         return ElementReq{x_req: x_req, y_req: y_req};
     }
+
+
+    /// Update element X allocation
+    pub fn update_x_req(&mut self, x_req: &LReq) -> bool {
+        let changed: bool = *x_req != self.x_req;
+        self.x_req.clone_from(x_req);
+        return changed;
+    }
+
+    /// Update element Y allocation
+    pub fn update_y_req(&mut self, y_req: &LReq) -> bool {
+        let changed: bool = *y_req != self.y_req;
+        self.y_req.clone_from(y_req);
+        return changed;
+    }
 }
 
 
@@ -35,6 +52,89 @@ pub struct ElementAlloc {
 impl ElementAlloc {
     pub fn new() -> ElementAlloc {
         return ElementAlloc{x_alloc: LAlloc::new_empty(), y_alloc: LAlloc::new_empty(),
-                            layout_flags: LAYOUT_FLAGS_ALL_CLEAN};
+                            layout_flags: LAYOUT_FLAGS_ALL_DIRTY};
+    }
+
+    /// Update element X allocation
+    pub fn update_x_alloc(&mut self, x_alloc: &LAlloc) -> bool {
+        let changed: bool = *x_alloc != self.x_alloc;
+        self.x_alloc.clone_from(x_alloc);
+        return changed;
+    }
+
+    /// Update element Y allocation
+    pub fn update_y_alloc(&mut self, y_alloc: &LAlloc) -> bool {
+        let changed: bool = *y_alloc != self.y_alloc;
+        self.y_alloc.clone_from(y_alloc);
+        return changed;
+    }
+
+    // Check if updates required
+    pub fn is_x_req_update_required(&self) -> bool {
+        return self.layout_flags & LAYOUT_FLAG_X_REQ_DIRTY != 0;
+    }
+
+    pub fn is_y_req_update_required(&self) -> bool {
+        return self.layout_flags & LAYOUT_FLAG_Y_REQ_DIRTY != 0;
+    }
+
+    pub fn is_x_alloc_update_required(&self) -> bool {
+        return self.layout_flags & LAYOUT_FLAG_X_ALLOC_DIRTY != 0;
+    }
+
+    pub fn is_y_alloc_update_required(&self) -> bool {
+        return self.layout_flags & LAYOUT_FLAG_Y_ALLOC_DIRTY != 0;
+    }
+
+    // Clear and set dirty flags
+    pub fn x_req_updated(&mut self) {
+        self.layout_flags = self.layout_flags & !LAYOUT_FLAG_X_REQ_DIRTY;
+    }
+
+    pub fn y_req_updated(&mut self) {
+        self.layout_flags = self.layout_flags & !LAYOUT_FLAG_Y_REQ_DIRTY;
+    }
+
+    pub fn x_alloc_updated(&mut self) {
+        self.layout_flags = self.layout_flags & !LAYOUT_FLAG_X_ALLOC_DIRTY;
+    }
+
+    pub fn y_alloc_updated(&mut self) {
+        self.layout_flags = self.layout_flags & !LAYOUT_FLAG_Y_ALLOC_DIRTY;
+    }
+
+    pub fn x_req_dirty(&mut self) {
+        self.layout_flags = self.layout_flags | LAYOUT_FLAG_X_REQ_DIRTY;
+    }
+
+    pub fn y_req_dirty(&mut self) {
+        self.layout_flags = self.layout_flags | LAYOUT_FLAG_Y_REQ_DIRTY;
+    }
+
+    pub fn x_alloc_dirty(&mut self) {
+        self.layout_flags = self.layout_flags | LAYOUT_FLAG_X_ALLOC_DIRTY;
+    }
+
+    pub fn y_alloc_dirty(&mut self) {
+        self.layout_flags = self.layout_flags | LAYOUT_FLAG_Y_ALLOC_DIRTY;
+    }
+
+    // Modifications
+    pub fn notify_requisition_changed(elem: &TElement) {
+        ElementAlloc::set_flags_on_path_to_root(elem, LAYOUT_FLAG_X_REQ_DIRTY | LAYOUT_FLAG_Y_REQ_DIRTY);
+    }
+
+    fn set_flags_on_path_to_root(elem: &TElement, flags: u8) {
+        let mut alloc = elem.element_alloc_mut();
+        alloc.layout_flags = alloc.layout_flags | flags;
+
+        let mut p_ref: Option<ElementRef> = elem.get_parent();
+        while p_ref.is_some() {
+            let p = p_ref.unwrap();
+            let mut p_alloc = p.element_alloc_mut();
+            p_alloc.layout_flags = alloc.layout_flags | flags;
+
+            p_ref = p.get_parent();
+        }
     }
 }


### PR DESCRIPTION
The incremental layout algorithm only updates element layout - position and size - when necessary due to changes in content or state. Elements that are unaffected by a change are left as is.

For example, modifying the content of an element would necessitate re-arranging the elements on the path between the modified element and the root, while resizing the window would necessitate re-computing x-positions and widths.
