### PR TITLE
Added `simple_editor` example.

### DIFF
--- a/examples/simple_editor.rs
+++ b/examples/simple_editor.rs
@@ -1,0 +1,110 @@
+#![cfg_attr(not(feature = "gtk_3_10"), allow(unused_variables, unused_mut))]
+
+extern crate time;
+extern crate gtk;
+extern crate gdk;
+extern crate cairo;
+extern crate lspace;
+
+use std::string::String;
+use std::rc::Rc;
+
+use gtk::traits::*;
+use gtk::signal::Inhibit;
+
+// for a list of key names see: http://gtk-rs.org/docs/gdk/enums/key/index.html
+use gdk::enums::key;
+
+use lspace::geom::colour::Colour;
+use lspace::elements::element::{ElementRef, elem_as_ref};
+use lspace::elements::container_sequence::TContainerSequenceElement;
+use lspace::elements::{text_element, row, column};
+use lspace::input::keyboard::{KeyEventType, KeyEvent, TKeyboardInteractor};
+use lspace::lspace_widget::LSpaceWidget;
+use lspace::lspace_area::LSpaceArea;
+
+
+struct LineEditor {
+    text_elem: ElementRef
+}
+
+impl LineEditor {
+    pub fn new(elem: &ElementRef) -> Rc<LineEditor> {
+        Rc::new(LineEditor{text_elem: elem.clone()})
+    }
+}
+
+impl TKeyboardInteractor for LineEditor {
+    fn on_key_event(&self, event: &KeyEvent) {
+        if event.event_type() == KeyEventType::Press {
+            let mut text = self.text_elem.as_text_element().unwrap().get_text().clone();
+            println!("Key val = {}", event.key_val());
+            if event.key_val() == key::BackSpace as u32 {
+                // Backspace
+                println!("Deleting");
+                let n = text.len();
+                let new_text = String::from(&text[0..n-1]);
+                self.text_elem.as_text_element().unwrap().set_text(new_text);
+            } else if event.key_val() == key::Shift_L as u32 ||
+                      event.key_val() == key::Shift_R as u32 {
+                // ignore
+            }
+            else {
+                println!("Inserting {:?}", event.key_string());
+                let new_text = text + event.key_string();
+                self.text_elem.as_text_element().unwrap().set_text(new_text);
+            }
+        }
+    }
+}
+
+
+fn main() {
+    // Initialise GTK
+    gtk::init().unwrap_or_else(|_| panic!("Failed to initialize GTK."));
+
+    let text_style = Rc::new(text_element::TextStyleParams::default());
+    let eol_style = Rc::new(text_element::TextStyleParams::new(String::from("Helvetica"),
+        text_element::TextWeight::Normal, text_element::TextSlant::Normal, 11.0, &Colour::new(0.0, 0.5, 1.0, 1.0)));
+
+    let lspace = LSpaceArea::new();
+
+    let text = elem_as_ref(text_element::TextElement::new_in_area(String::from("Hello world"), text_style, &lspace));
+
+    let end_of_line = elem_as_ref(text_element::TextElement::new_in_area(String::from("}{"), eol_style, &lspace));
+
+    let editor_as_interactor: Rc<TKeyboardInteractor> = LineEditor::new(&text);
+
+    let line = elem_as_ref(row::RowElement::new(0.0));
+    line.as_container_sequence().unwrap().set_children(&line, &vec![text, end_of_line]);
+
+    let content = elem_as_ref(column::ColumnElement::new(0.0));
+    content.as_container_sequence().unwrap().set_children(&content, &vec![line]);
+
+    lspace.set_content_element(content);
+
+    lspace.keyboard().add_interactor(&editor_as_interactor);
+
+    // Create the LSpace widget, showing our content
+    let lsw = LSpaceWidget::new_with_area(lspace);
+    let widget = lsw.gtk_widget();
+    widget.grab_focus();
+
+    // Create a GTK window in which to place it
+    let window = gtk::Window::new(gtk::WindowType::Toplevel).unwrap();
+    window.set_title("Very Simple Editor");
+    window.add(&*widget);
+    window.set_default_size(800, 500);
+
+    // Quit the GTK main loop when the window is closed
+    window.connect_delete_event(|_, _| {
+        gtk::main_quit();
+        Inhibit(true)
+    });
+
+    // Show everything
+    window.show_all();
+
+    // Enter GTK main loop
+    gtk::main();
+}

--- a/src/lib/lspace/lspace_widget.rs
+++ b/src/lib/lspace/lspace_widget.rs
@@ -4,7 +4,8 @@ extern crate time;
 
 use std::rc::Rc;
 use std::cell::RefCell;
-use std::ptr;
+use std::ffi::CStr;
+use libc::c_char;
 
 use gdk::ffi as gdk_ffi;
 use gdk::enums::modifier_type;
@@ -140,11 +141,9 @@ impl LSpaceWidgetMut {
             let state_clone = wrapped_area.clone();
             drawing_area.connect_key_press_event(move |widget, event_key| {
                 let mod_state = gdk_modifier_to_input_mod_state(event_key.state);
-                let mut key_string = String::new();
-                unsafe {
-                    key_string.push(ptr::read(event_key.string));
-                }
-                state_clone.on_key_press(mod_state, event_key.keyval, key_string);
+                let c_key_str = event_key.string as *const c_char;
+                let k_str = unsafe{CStr::from_ptr(c_key_str)}.to_str().unwrap().to_string();
+                state_clone.on_key_press(mod_state, event_key.keyval, k_str);
                 Inhibit(true)
             });
         }
@@ -153,11 +152,9 @@ impl LSpaceWidgetMut {
             let state_clone = wrapped_area.clone();
             drawing_area.connect_key_release_event(move |widget, event_key| {
                 let mod_state = gdk_modifier_to_input_mod_state(event_key.state);
-                let mut key_string = String::new();
-                unsafe {
-                    key_string.push(ptr::read(event_key.string));
-                }
-                state_clone.on_key_release(mod_state, event_key.keyval, key_string);
+                let c_key_str = event_key.string as *const c_char;
+                let k_str = unsafe{CStr::from_ptr(c_key_str)}.to_str().unwrap().to_string();
+                state_clone.on_key_release(mod_state, event_key.keyval, k_str);
                 Inhibit(true)
             });
         }


### PR DESCRIPTION
Fixed handling of C strings in key event handling functions in `lspace_widget`.
